### PR TITLE
[機能開発]Materialにモデルスペックを実装

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -52,3 +52,7 @@ Layout/CommentIndentation:
 # 最大ネスト
 RSpec/NestedGroups:
   Max: 10
+
+# 最大expect数
+RSpec/MultipleExpectations:
+  Max: 10

--- a/app/models/material.rb
+++ b/app/models/material.rb
@@ -1,3 +1,8 @@
 class Material < ApplicationRecord
   belongs_to :content
+
+  validates :name,   length: { in: 1..16, allow_blank: true }
+  validates :amount, length: { in: 1..5,  allow_blank: true }, numericality: { only_integer: true }
+  # TDOO: enumを使用して選択できる様にするか検討する
+  validates :unit,   length: { in: 1..5,  allow_blank: true }
 end

--- a/app/models/material.rb
+++ b/app/models/material.rb
@@ -1,8 +1,8 @@
 class Material < ApplicationRecord
   belongs_to :content
 
-  validates :name,   length: { in: 1..16, allow_blank: true }
-  validates :amount, length: { in: 1..5,  allow_blank: true }, numericality: { only_integer: true }
+  validates :name,   presence: true, length: { in: 1..16, allow_blank: true }
+  validates :amount, presence: true, length: { in: 1..5, allow_blank: true }, numericality: { only_integer: true }
   # TDOO: enumを使用して選択できる様にするか検討する
-  validates :unit,   length: { in: 1..5,  allow_blank: true }
+  validates :unit,   presence: true, length: { in: 1..5, allow_blank: true }
 end

--- a/spec/factories/materials.rb
+++ b/spec/factories/materials.rb
@@ -1,8 +1,8 @@
 FactoryBot.define do
   factory :material do
-    content { nil }
-    name { "MyString" }
+    association :content, factory: :content
+    name { "ねじ" }
     amount { 1 }
-    unit { "MyString" }
+    unit { "本" }
   end
 end

--- a/spec/models/material_spec.rb
+++ b/spec/models/material_spec.rb
@@ -1,5 +1,77 @@
 require "rails_helper"
 
 RSpec.describe Material, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe "validation" do
+    subject { material.valid? }
+
+    context "データが条件を満たす時" do
+      let(:material) { build(:material) }
+      it "保存ができる" do
+        expect(subject).to eq true
+      end
+    end
+
+    describe "name" do
+      context "入力さていない時" do
+        let(:material) { build(:material, name: "") }
+        it "保存ができない" do
+          expect(subject).to eq false
+          expect(material.errors[:name]).to include "を入力してください"
+        end
+      end
+
+      context "16文字以上の場合" do
+        let(:material) { build(:material, name: "1" * 17) }
+        it "保存ができない" do
+          expect(subject).to eq false
+          expect(material.errors.messages[:name]).to include "は16文字以内で入力してください"
+        end
+      end
+    end
+
+    describe "amount" do
+      context "入力さていない時", type: :do do
+        let(:material) { build(:material, amount: "") }
+        it "エラーが出力される" do
+          expect(subject).to eq false
+          expect(material.errors[:amount]).to include "を入力してください"
+        end
+      end
+
+      context "5文字以上の場合" do
+        let(:material) { build(:material, amount: "1" * 6) }
+        it "エラーが出力される" do
+          expect(subject).to eq false
+          expect(material.errors.messages[:amount]).to include "は5文字以内で入力してください"
+        end
+      end
+
+      context "数字以外の場合" do
+        let(:material) { build(:material, amount: "a" * 5) }
+
+        it "エラーが出力される" do
+          expect(subject).to eq false
+          expect(material.errors.messages[:amount]).to include "は数値で入力してください"
+        end
+      end
+    end
+
+    describe "unit" do
+      context "入力さていない時" do
+        let(:material) { build(:material, unit: "") }
+        it "保存ができない" do
+          expect(subject).to eq false
+          expect(material.errors[:unit]).to include "を入力してください"
+        end
+      end
+
+      context "5文字以上の場合" do
+        let(:material) { build(:material, unit: "1" * 6) }
+        it "保存ができない" do
+          expect(subject).to eq false
+          expect(material.errors.messages[:unit]).to include "は5文字以内で入力してください"
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
## 実装の目的と概要
- Materialにモデルスペックを実装

## 実装内容(技術的な点を記載)
- Materialにバリデージョンを実装
- Materialにモデルスペックを実装
 
## 確認用コマンド
```
 rspec spec/models/material_spec.rb
```


## チェックリスト

- [x] ローカル環境での動作確認をしたか（影響し得る範囲も含めて）
- [x] rubocopを実行して警告が出力されていないか
- [x] GitHub で ファイル差分（Files changed）を確認し、内容が合っているか。不要なファイルに差分がでていないか
- [x] テストでエラーが発生していないか

