### PR TITLE
[機能開発]Makeにモデルスペックを実装

### DIFF
--- a/app/models/make.rb
+++ b/app/models/make.rb
@@ -1,3 +1,6 @@
 class Make < ApplicationRecord
   belongs_to :content
+
+  # CHECK: 32文字で足りるかどうか
+  validates :detail, presence: true, length: { in: 1..32, allow_blank: true }
 end

--- a/spec/factories/makes.rb
+++ b/spec/factories/makes.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :make do
-    content { nil }
-    detail { "MyString" }
+    association :content, factory: :content
+    detail { "作り方はこちら" }
   end
 end

--- a/spec/models/make_spec.rb
+++ b/spec/models/make_spec.rb
@@ -1,5 +1,32 @@
 require "rails_helper"
 
 RSpec.describe Make, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe "validation" do
+    subject { make.valid? }
+
+    context "データが条件を満たす時" do
+      let(:make) { build(:make) }
+      it "保存ができる" do
+        expect(subject).to eq true
+      end
+    end
+
+    describe "detail" do
+      context "入力さていない時" do
+        let(:make) { build(:make, detail: "") }
+        it "保存ができない" do
+          expect(subject).to eq false
+          expect(make.errors[:detail]).to include "を入力してください"
+        end
+      end
+
+      context "32文字以上の場合" do
+        let(:make) { build(:make, detail: "1" * 33) }
+        it "保存ができない" do
+          expect(subject).to eq false
+          expect(make.errors.messages[:detail]).to include "は32文字以内で入力してください"
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
## 実装の目的と概要
- Makeにモデルスペックを実装

## 実装内容(技術的な点を記載)
- Makeにモデルスペックを実装
- バリデージョン を追加

## 確認用コマンド
```
rspec spec/models/make_spec.rb
```

## チェックリスト

- [x] ローカル環境での動作確認をしたか（影響し得る範囲も含めて）
- [x] rubocopを実行して警告が出力されていないか
- [x] GitHub で ファイル差分（Files changed）を確認し、内容が合っているか。不要なファイルに差分がでていないか
- [x] テストでエラーが発生していないか
