### PR TITLE
[機能開発]Contentのリクエストスペックを実装する

### DIFF
--- a/app/controllers/contents_controller.rb
+++ b/app/controllers/contents_controller.rb
@@ -26,7 +26,7 @@ class ContentsController < ApplicationController
 
   def update
     if @content.update(content_params)
-      redirect_to content_show_path(id: @content.id), notice: "【#{@content.title}】の内容を更新しました"
+      redirect_to content_show_path(id: @content.id), notice: "内容を更新しました"
     else
       render :edit
     end

--- a/spec/factories/contents.rb
+++ b/spec/factories/contents.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :content do
     title { "コンテンツタイトル" }
     subtitle { "サブタイトル" }
-    # movie_url { "" }
+    movie_url { "URL" }
     comment { "コメント" }
     point { "ポイント" }
     # recommend_status { 1 }

--- a/spec/models/material_spec.rb
+++ b/spec/models/material_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Material, type: :model do
     end
 
     describe "amount" do
-      context "入力さていない時", type: :do do
+      context "入力さていない時" do
         let(:material) { build(:material, amount: "") }
         it "エラーが出力される" do
           expect(subject).to eq false

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -33,6 +33,8 @@ end
 RSpec.configure do |config|
   config.include FactoryBot::Syntax::Methods # FactoryBotを省略
   Faker::Config.locale = :ja # 日本語のダミーデータを使用
+  config.include Devise::Test::ControllerHelpers, type: :controller
+  config.include Devise::Test::IntegrationHelpers, type: :request
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
 

--- a/spec/requests/contents_spec.rb
+++ b/spec/requests/contents_spec.rb
@@ -1,7 +1,299 @@
+## TODO: 文言を統一すること
+
 require "rails_helper"
 
 RSpec.describe "Contents", type: :request do
-  describe "GET /index" do
-    pending "add some examples (or delete) #{__FILE__}"
+  before do
+    @user = FactoryBot.create(:user) # ユーザー
+    @admin = FactoryBot.create(:user, user_type: "admin") # 管理者
+  end
+
+  describe "GET #index" do
+    subject { get(contents_path) }
+
+    create_content = 3
+
+    context "コンテンツが存在する場合" do
+      before { create_list(:content, create_content) }
+
+      it "コンテンツ一覧を取得できること" do
+        subject
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include(*Content.pluck(:title))
+        # TODO: youtube動画登録機能実装時に使用する
+        # expect(response.body).to include(*Content.pluck(:thumbnail))
+        expect(Content.count).to eq(create_content)
+      end
+    end
+
+    # TOOD: capybara部分は別タスクで実行する
+    context "画面に遷移した時" do
+      context "未ログインユーザーの場合" do
+        xit "新規登録ボタンが表示されない" do
+          # 表示されない処理
+        end
+      end
+
+      context "ユーザーが管理者の場合" do
+        xit "新規登録ボタンが表示される" do
+          sign_in @user
+          # 表示される処理
+        end
+      end
+
+      context "ユーザーが管理者でない場合" do
+        xit "新規登録ボタンが表示されない" do
+          sign_in @admin
+          # 表示されない処理
+        end
+      end
+    end
+  end
+
+  describe "GET #new" do
+    subject { get(new_content_path) }
+
+    context "未ログインユーザーの場合" do
+      it "リダイレクトする" do
+        subject
+        expect(response).to have_http_status(:found)
+        expect(response).to redirect_to root_path
+      end
+    end
+
+    context "ユーザーが管理者の場合" do
+      it "リスクエストが成功する" do
+        sign_in @admin
+        subject
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "ユーザーが管理者でない場合" do
+      it "リダイレクトする" do
+        sign_in @user
+        subject
+        expect(response).to have_http_status(:found)
+        expect(response).to redirect_to root_path
+      end
+    end
+  end
+
+  describe "GET #show" do
+    subject { get(content_show_path(content_id)) }
+
+    context "コンテンツが存在するとき" do
+      let(:content) { create(:content) }
+      let(:content_id) { content.id }
+
+      context "コンテンツが存在する場合" do
+        it "指定したidのコンテンツが取得できる" do
+          subject
+          expect(response).to have_http_status(:ok)
+          expect(response.body).to include content.title
+          expect(response.body).to include content.subtitle
+          # expect(response.body).to include content.movie_url
+          expect(response.body).to include content.comment
+          expect(response.body).to include content.point
+        end
+      end
+
+      context "コンテンツが存在しない場合" do
+        let(:content_id) { 0 }
+        it "エラーが発生する" do
+          # TODO: 将来404へ遷移する様にする
+          expect { subject }.to raise_error(ActiveRecord::RecordNotFound)
+        end
+      end
+
+    # TOOD: capybara部分は別タスクで実行する
+      context "未ログインユーザーの場合" do
+        xit "xxボタンが表示されないこと" do
+          ## テスト
+        end
+      end
+
+      context "管理者でない場合" do
+        xit "xxボタンが表示されないこと" do
+          sign_in @user
+          ## テスト
+        end
+      end
+
+      context "管理者の場合" do
+        xit "xxボタンが表示されること" do
+          sign_in @admin
+          ## テスト
+        end
+      end
+    end
+  end
+
+  describe "POST #create" do
+    subject { post(contents_path, params: content_params) }
+
+    let(:content_params) {
+      { content: {
+        title: "新規タイトル",
+        subtitle: "新規サブタイトル",
+        movie_url: "新規URL",
+        comment: "新規コメント",
+        point: "新規ポイント！",
+      } }
+    }
+
+    context "未ログインユーザの場合" do
+      it "コンテンツの件数が変化しないこと" do
+        expect { subject }.to change { Content.count }.by(0)
+        expect(response).to have_http_status(:found)
+        expect(response).to redirect_to root_path
+        expect(flash[:alert]).to eq("不正なアクセスです")
+      end
+    end
+
+    context "管理者でない場合" do
+      it "コンテンツの件数が変化しないこと" do
+        sign_in @user
+        expect { subject }.to change { Content.count }.by(0)
+        expect(response).to have_http_status(:found)
+        expect(response).to redirect_to root_path
+        expect(flash[:alert]).to eq("不正なアクセスです")
+      end
+    end
+
+    context "管理者の場合" do
+      it "コンテンツの件数が1件増加すること" do
+        sign_in @admin
+        expect { subject }.to change { Content.count }.by(1)
+        expect(response).to have_http_status(:found)
+        expect(response).to redirect_to content_show_path(Content.last)
+        expect(flash[:notice]).to eq("【#{Content.last.title}】を作成しました")
+      end
+    end
+
+    describe "PUT #update" do
+      subject { patch(content_path(content.id), params: content_params) }
+
+      let(:content) { create(:content) }
+      let(:content_params) {
+        { content: {
+          title: "更新タイトル",
+          subtitle: "更新サブタイトル",
+          movie_url: "更新URL",
+          comment: "更新コメント",
+          point: "更新ポイント！",
+        } }
+      }
+
+      context "未ログインユーザーの場合" do
+        it "リダイレクトすること" do
+          subject
+          expect(response).to have_http_status(:found)
+          expect(response).to redirect_to root_path
+          expect(flash[:alert]).to eq("不正なアクセスです")
+        end
+      end
+
+      context "管理者でない場合" do
+        it "リダイレクトすること" do
+          sign_in @user
+          subject
+          expect(response).to have_http_status(:found)
+          expect(response).to redirect_to root_path
+          expect(flash[:alert]).to eq("不正なアクセスです")
+        end
+      end
+
+      context "管理者の場合"
+
+        it "コンテンツが更新されること" do # rubocop:disable all
+          sign_in @admin
+          new_content = content_params[:content]
+          expect { subject }.to change { content.reload.title }.from(content.title).to(new_content[:title]).
+                                  and change { content.reload.subtitle }.from(content.subtitle).to(new_content[:subtitle]).
+                                        and change { content.reload.movie_url }.from(content.movie_url).to(new_content[:movie_url]).
+                                              and change { content.reload.comment }.from(content.comment).to(new_content[:comment]).
+                                                    and change { content.reload.point }.from(content.point).to(new_content[:point])
+          expect(response).to have_http_status(:found)
+          expect(response).to redirect_to content_show_path(Content.last)
+          expect(flash[:notice]).to eq("内容を更新しました")
+        end
+    end
+  end
+
+  describe "GET #edit" do
+    subject { get(edit_content_path(content_id)) }
+
+    let(:content) { create(:content) }
+    let(:content_id) { content.id }
+
+    context "未ログインユーザーの場合" do
+      it "リダイレクトされること" do
+        subject
+        expect(response).to have_http_status(:found)
+        expect(response).to redirect_to root_path
+        expect(flash[:alert]).to eq("不正なアクセスです")
+      end
+    end
+
+    context "管理者でない場合" do
+      it "リダイレクトされること" do
+        sign_in @user
+        subject
+        expect(response).to have_http_status(:found)
+        expect(response).to redirect_to root_path
+        expect(flash[:alert]).to eq("不正なアクセスです")
+      end
+    end
+
+    context "管理者の場合" do
+      it "指定したidのコンテンツが表示されること" do
+        sign_in @admin
+        subject
+        expect(response.body).to include content.title
+        expect(response.body).to include content.subtitle
+        expect(response.body).to include content.movie_url
+        expect(response.body).to include content.comment
+        expect(response.body).to include content.point
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
+
+  describe "GET #destroy" do
+    subject { delete(content_path(@content.id)) }
+
+    before { @content = create(:content) }
+
+    context "未ログインユーザーの場合" do
+      it "リダイレクトされること" do
+        expect { subject }.to change { Content.count }.by(0)
+        expect(response).to have_http_status(:found)
+        expect(response).to redirect_to root_path
+        expect(flash[:alert]).to eq("不正なアクセスです")
+      end
+    end
+
+    context "管理者でない場合" do
+      it "リダイレクトされること" do
+        sign_in @user
+        expect { subject }.to change { Content.count }.by(0)
+        expect(response).to have_http_status(:found)
+        expect(response).to redirect_to root_path
+        expect(flash[:alert]).to eq("不正なアクセスです")
+      end
+    end
+
+    context "管理者の場合" do
+      before { @content = create(:content) }
+
+      it "コンテンツが削除されること" do
+        sign_in @admin
+        expect { subject }.to change { Content.count }.by(-1)
+        expect(response).to have_http_status(:found)
+        expect(response).to redirect_to contents_path
+        expect(flash[:alert]).to eq("【#{@content.title}】を削除しました")
+      end
+    end
   end
 end

--- a/spec/requests/contents_spec.rb
+++ b/spec/requests/contents_spec.rb
@@ -34,17 +34,17 @@ RSpec.describe "Contents", type: :request do
         end
       end
 
-      context "ユーザーが管理者の場合" do
-        xit "新規登録ボタンが表示される" do
-          sign_in @user
-          # 表示される処理
-        end
-      end
-
       context "ユーザーが管理者でない場合" do
         xit "新規登録ボタンが表示されない" do
           sign_in @admin
           # 表示されない処理
+        end
+      end
+
+      context "ユーザーが管理者の場合" do
+        xit "新規登録ボタンが表示される" do
+          sign_in @user
+          # 表示される処理
         end
       end
     end
@@ -113,14 +113,14 @@ RSpec.describe "Contents", type: :request do
         end
       end
 
-      context "管理者でない場合" do
+      context "ユーザーが管理者でない場合" do
         xit "xxボタンが表示されないこと" do
           sign_in @user
           ## テスト
         end
       end
 
-      context "管理者の場合" do
+      context "ユーザーが管理者の場合" do
         xit "xxボタンが表示されること" do
           sign_in @admin
           ## テスト
@@ -151,7 +151,7 @@ RSpec.describe "Contents", type: :request do
       end
     end
 
-    context "管理者でない場合" do
+    context "ユーザーが管理者でない場合" do
       it "コンテンツの件数が変化しないこと" do
         sign_in @user
         expect { subject }.to change { Content.count }.by(0)
@@ -161,7 +161,7 @@ RSpec.describe "Contents", type: :request do
       end
     end
 
-    context "管理者の場合" do
+    context "ユーザーが管理者の場合" do
       it "コンテンツの件数が1件増加すること" do
         sign_in @admin
         expect { subject }.to change { Content.count }.by(1)
@@ -194,7 +194,7 @@ RSpec.describe "Contents", type: :request do
         end
       end
 
-      context "管理者でない場合" do
+      context "ユーザーが管理者でない場合" do
         it "リダイレクトすること" do
           sign_in @user
           subject
@@ -204,7 +204,7 @@ RSpec.describe "Contents", type: :request do
         end
       end
 
-      context "管理者の場合"
+      context "ユーザーが管理者の場合"
 
         it "コンテンツが更新されること" do # rubocop:disable all
           sign_in @admin
@@ -236,7 +236,7 @@ RSpec.describe "Contents", type: :request do
       end
     end
 
-    context "管理者でない場合" do
+    context "ユーザーが管理者でない場合" do
       it "リダイレクトされること" do
         sign_in @user
         subject
@@ -246,7 +246,7 @@ RSpec.describe "Contents", type: :request do
       end
     end
 
-    context "管理者の場合" do
+    context "ユーザーが管理者の場合" do
       it "指定したidのコンテンツが表示されること" do
         sign_in @admin
         subject
@@ -274,7 +274,7 @@ RSpec.describe "Contents", type: :request do
       end
     end
 
-    context "管理者でない場合" do
+    context "ユーザーが管理者でない場合" do
       it "リダイレクトされること" do
         sign_in @user
         expect { subject }.to change { Content.count }.by(0)
@@ -284,7 +284,7 @@ RSpec.describe "Contents", type: :request do
       end
     end
 
-    context "管理者の場合" do
+    context "ユーザーが管理者の場合" do
       before { @content = create(:content) }
 
       it "コンテンツが削除されること" do


### PR DESCRIPTION
## 実装の目的と概要
- Contentのリクエストスペックを実装する

## 実装内容(技術的な点を記載)
- `contents_spec.rb`の実装

## 重点的に見てほしいところ(不安なところ)
- テストが通過するかどうか 
  - フラッシュの文言を調整
  - contents.rbを調整

## 確認用コマンド
```
rspec spec/requests/contents_spec.rb
```

## 参考資料
- [RSpec 要素数はhave(n).items じゃなくなってる](https://qiita.com/sakaimo/items/50989ab44b87e1132a91)
テーブルに作成された数だけコンテンツが表示されているかどうかのテストを実装する時に参考
```rb
    expect(Content.count).to eq (CREATE_CONTENT)
```
- [change + from / to / by
](https://qiita.com/jnchito/items/2e79a1abe7cd8214caa5#change--from--to--by)


## チェックリスト

- [x] ローカル環境での動作確認をしたか（影響し得る範囲も含めて）
- [x] rubocopを実行して警告が出力されていないか
- [x] GitHub で ファイル差分（Files changed）を確認し、内容が合っているか。不要なファイルに差分がでていないか
- [x] テストでエラーが発生していないか

## 備考（実装していないことなど）
- 画面遷移に関するテストは別タスクで実装する
