### PR TITLE
[機能開発]Makeのリクエストスペックを実装

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,4 +2,9 @@ class ApplicationController < ActionController::Base
   def redirect_root
     redirect_back(fallback_location: root_path) and return
   end
+
+  def admin_checker
+    redirect_to root_path, alert: "不正なアクセスです" and return unless user_signed_in?     # ログインしているか
+    redirect_to root_path, alert: "不正なアクセスです" and return unless current_user.admin? # ログインユーザーが管理者か
+  end
 end

--- a/app/controllers/contents_controller.rb
+++ b/app/controllers/contents_controller.rb
@@ -50,12 +50,4 @@ class ContentsController < ApplicationController
     def content_params
       params.require(:content).permit(:title, :subtitle, :movie_url, :comment, :point)
     end
-
-    # TODO: 共通化すること
-    def admin_checker
-      ## ログインしているか
-      redirect_to root_path, alert: "不正なアクセスです" and return unless user_signed_in?
-      ## ログインユーザーが管理者か
-      redirect_to root_path, alert: "不正なアクセスです" and return unless current_user.admin?
-    end
 end

--- a/app/controllers/makes_controller.rb
+++ b/app/controllers/makes_controller.rb
@@ -1,5 +1,5 @@
 class MakesController < ApplicationController
-  # before_action :admin_checker, only: %i[new create update edit destroy]
+  before_action :admin_checker, only: %i[new create update edit destroy]
   before_action :set_make, only: %i[update edit destroy]
 
   def new

--- a/app/controllers/materials_controller.rb
+++ b/app/controllers/materials_controller.rb
@@ -1,5 +1,5 @@
 class MaterialsController < ApplicationController
-  # before_action :admin_checker, only: %i[new create update edit destroy]
+  before_action :admin_checker, only: %i[new create update edit destroy]
   before_action :set_material, only: %i[update edit destroy]
 
   def new

--- a/spec/factories/makes.rb
+++ b/spec/factories/makes.rb
@@ -1,6 +1,10 @@
 FactoryBot.define do
   factory :make do
     association :content, factory: :content
-    detail { "作り方はこちら" }
+    detail { Faker::Book.title }
+  end
+
+  trait :invalid do
+    detail { "" }
   end
 end

--- a/spec/models/content_spec.rb
+++ b/spec/models/content_spec.rb
@@ -112,6 +112,15 @@ RSpec.describe Content, type: :model do
           end
         end
       end
+
+      describe "content_delete" do
+        context "contentが削除された時" do
+          xit "紐づいている情報も削除される" do
+            # 材料
+            # 作り方
+          end
+        end
+      end
     end
   end
 end

--- a/spec/requests/contents_spec.rb
+++ b/spec/requests/contents_spec.rb
@@ -58,14 +58,7 @@ RSpec.describe "Contents", type: :request do
         subject
         expect(response).to have_http_status(:found)
         expect(response).to redirect_to root_path
-      end
-    end
-
-    context "ユーザーが管理者の場合" do
-      it "リスクエストが成功する" do
-        sign_in @admin
-        subject
-        expect(response).to have_http_status(:ok)
+        expect(flash[:alert]).to eq("不正なアクセスです")
       end
     end
 
@@ -75,6 +68,15 @@ RSpec.describe "Contents", type: :request do
         subject
         expect(response).to have_http_status(:found)
         expect(response).to redirect_to root_path
+        expect(flash[:alert]).to eq("不正なアクセスです")
+      end
+
+      context "ユーザーが管理者の場合" do
+        it "リスクエストが成功する" do
+          sign_in @admin
+          subject
+          expect(response).to have_http_status(:ok)
+        end
       end
     end
   end
@@ -109,21 +111,27 @@ RSpec.describe "Contents", type: :request do
     # TOOD: capybara部分は別タスクで実行する
       context "未ログインユーザーの場合" do
         xit "xxボタンが表示されないこと" do
-          ## テスト
+          # テスト
+          # 作り方（追加・編集・削除）
+          # 材料
         end
       end
 
       context "ユーザーが管理者でない場合" do
         xit "xxボタンが表示されないこと" do
           sign_in @user
-          ## テスト
+          # テスト
+          # 作り方（追加・編集・削除）
+          # 材料
         end
       end
 
       context "ユーザーが管理者の場合" do
         xit "xxボタンが表示されること" do
           sign_in @admin
-          ## テスト
+          # テスト
+          # 作り方（追加・編集・削除）
+          # 材料
         end
       end
     end

--- a/spec/requests/makes_spec.rb
+++ b/spec/requests/makes_spec.rb
@@ -1,7 +1,213 @@
 require "rails_helper"
 
 RSpec.describe "Makes", type: :request do
-  describe "GET /index" do
-    pending "add some examples (or delete) #{__FILE__}"
+  before do
+    @user = FactoryBot.create(:user) # ユーザー
+    @admin = FactoryBot.create(:user, user_type: "admin") # 管理者
+  end
+
+  describe "GET #new" do
+    subject { get(new_make_path) }
+
+    context "未ログインユーザーの場合" do
+      it "リダイレクトする" do
+        subject
+        expect(response).to have_http_status(:found)
+        expect(response).to redirect_to root_path
+        expect(flash[:alert]).to eq("不正なアクセスです")
+      end
+    end
+
+    context "ユーザーが管理者でない場合" do
+      it "リダイレクトする" do
+        sign_in @user
+        subject
+        expect(response).to have_http_status(:found)
+        expect(response).to redirect_to root_path
+        expect(flash[:alert]).to eq("不正なアクセスです")
+      end
+    end
+
+    context "ユーザーが管理者の場合" do
+      it "リスクエストが成功する" do
+        sign_in @admin
+        subject
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
+
+  describe "POST #create" do
+    subject { post(makes_path, params: make_params) }
+
+    let(:content) { create(:content) }
+    let(:make_params) { { make: attributes_for(:make, content_id: content.id) } }
+
+    context "未ログインユーザの場合" do
+      it "コンテンツの件数が変化しないこと" do
+        expect { subject }.to change { Make.count }.by(0)
+        expect(response).to have_http_status(:found)
+        expect(response).to redirect_to root_path
+        expect(flash[:alert]).to eq("不正なアクセスです")
+      end
+    end
+
+    context "ユーザーが管理者でない場合" do
+      it "コンテンツの件数が変化しないこと" do
+        sign_in @user
+        expect { subject }.to change { Make.count }.by(0)
+        expect(response).to have_http_status(:found)
+        expect(response).to redirect_to root_path
+        expect(flash[:alert]).to eq("不正なアクセスです")
+      end
+    end
+
+    context "ユーザーが管理者の場合" do
+      context "パラメータが正常な時" do
+        it "コンテンツの件数が1件増加すること" do
+          sign_in @admin
+          expect { subject }.to change { Make.count }.by(1)
+          expect(response).to have_http_status(:found)
+          expect(response).to redirect_to content_show_path(Make.last.content)
+          expect(flash[:notice]).to eq("作り方を追加しました")
+        end
+      end
+
+      context "パラメータが異常な時" do
+        let(:make_params) { { make: attributes_for(:make, :invalid, content_id: content.id) } }
+        it "コンテンツの件数が増加しないこと" do
+          sign_in @admin
+          expect { subject }.to change { Make.count }.by(0)
+          expect(response).to have_http_status(:ok)
+          # TODO: エラーメッセージが表示されること
+          # expect(response.body).to include "を入力してください"
+        end
+      end
+    end
+
+    describe "PUT #update" do
+      subject { patch(make_path(make.id), params: make_params) }
+
+      let(:content) { create(:content) }
+      let(:content_id) { content.id }
+      let(:make) { create(:make, content_id: content_id) }
+      let(:make_params) { { make: attributes_for(:make, content_id: content.id) } }
+
+      context "未ログインユーザーの場合" do
+        it "リダイレクトすること" do
+          subject
+          expect(response).to have_http_status(:found)
+          expect(response).to redirect_to root_path
+          expect(flash[:alert]).to eq("不正なアクセスです")
+        end
+      end
+
+      context "ユーザーが管理者でない場合" do
+        it "リダイレクトすること" do
+          sign_in @user
+          subject
+          expect(response).to have_http_status(:found)
+          expect(response).to redirect_to root_path
+          expect(flash[:alert]).to eq("不正なアクセスです")
+        end
+      end
+
+      context "ユーザーが管理者の場合" do
+        context "パラメータが正常な時" do
+          it "コンテンツが更新されること" do
+            sign_in @admin
+            new_make = make_params[:make]
+            expect { subject }.to change { make.reload.detail }.from(make.detail).to(new_make[:detail])
+            expect(response).to have_http_status(:found)
+            expect(response).to redirect_to content_show_path(make.content)
+            expect(flash[:notice]).to eq("作り方を更新しました")
+          end
+        end
+
+        context "パラメータが異常な時" do
+          let(:make_params) { { make: attributes_for(:make, :invalid, content_id: content.id) } }
+
+          it "コンテンツが更新できないこと" do
+            sign_in @admin
+            expect { subject }.not_to change { make.reload.detail }
+            expect(response).to have_http_status(:ok)
+            # TODO: エラーメッセージが表示されること
+            # expect(response.body).to include "を入力してください"
+          end
+        end
+      end
+    end
+  end
+
+  describe "GET #edit" do
+    subject { get(edit_make_path(make_id, content_id: content.id)) }
+
+    let(:content) { create(:content) }
+    let(:make) { create(:make, content_id: content.id) }
+    let(:make_id) { make.id }
+
+    context "未ログインユーザーの場合" do
+      it "リダイレクトされること" do
+        subject
+        expect(response).to have_http_status(:found)
+        expect(response).to redirect_to root_path
+        expect(flash[:alert]).to eq("不正なアクセスです")
+      end
+    end
+
+    context "ユーザーが管理者でない場合" do
+      it "リダイレクトされること" do
+        sign_in @user
+        subject
+        expect(response).to have_http_status(:found)
+        expect(response).to redirect_to root_path
+        expect(flash[:alert]).to eq("不正なアクセスです")
+      end
+    end
+
+    context "ユーザーが管理者の場合" do
+      it "指定したidの「作り方」が表示されること" do
+        sign_in @admin
+        subject
+        expect(response.body).to include make.detail
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
+
+  describe "GET #destroy" do
+    subject { delete(make_path(@make.id)) }
+
+    let(:content) { create(:content) }
+    before { @make = create(:make, content_id: content.id) }
+
+    context "未ログインユーザーの場合" do
+      it "リダイレクトされること" do
+        expect { subject }.to change { Make.count }.by(0)
+        expect(response).to have_http_status(:found)
+        expect(response).to redirect_to root_path
+        expect(flash[:alert]).to eq("不正なアクセスです")
+      end
+    end
+
+    context "ユーザーが管理者でない場合" do
+      it "リダイレクトされること" do
+        sign_in @user
+        expect { subject }.to change { Make.count }.by(0)
+        expect(response).to have_http_status(:found)
+        expect(response).to redirect_to root_path
+        expect(flash[:alert]).to eq("不正なアクセスです")
+      end
+    end
+
+    context "ユーザーが管理者の場合" do
+      it "コンテンツが削除されること" do
+        sign_in @admin
+        expect { subject }.to change { Make.count }.by(-1)
+        expect(response).to have_http_status(:found)
+        expect(response).to redirect_to content_show_path(@make.content)
+        expect(flash[:alert]).to eq("作り方を削除しました")
+      end
+    end
   end
 end


### PR DESCRIPTION
## 実装の目的と概要
- Makeのリクエストスペックを実装

## 実装内容(技術的な点を記載)
- [x] Makeのリクエストスペックを実装
- [x] テストデータにinvalidを追加/fakerの使用
- [x] `admin_checker`を共通化し、実装

## 重点的に見てほしいところ(不安なところ)
 - テストが通るか
 
## 確認用コマンド
```
❯ rspec spec/requests/makes_spec.rb
```


## チェックリスト

- [x] ローカル環境での動作確認をしたか（影響し得る範囲も含めて）
- [x] rubocopを実行して警告が出力されていないか
- [x] GitHub で ファイル差分（Files changed）を確認し、内容が合っているか。不要なファイルに差分がでていないか
- [x] テストでエラーが発生していないか

## 備考（実装していないことなど）
- エラーメッセージに関するテストは、別タスクにて対応する