### PR TITLE
[機能開発]Materialのリクエストスペックを実装

### DIFF
--- a/spec/factories/makes.rb
+++ b/spec/factories/makes.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
     detail { Faker::Book.title }
   end
 
-  trait :invalid do
+  trait :make_invalid do
     detail { "" }
   end
 end

--- a/spec/factories/materials.rb
+++ b/spec/factories/materials.rb
@@ -1,8 +1,12 @@
 FactoryBot.define do
   factory :material do
     association :content, factory: :content
-    name { "ねじ" }
-    amount { 1 }
-    unit { "本" }
+    name { Faker::Lorem.characters(number: 16) }
+    amount { Faker::Number.number(digits: 5) }
+    unit { Faker::Lorem.characters(number: 5) }
+  end
+
+  trait :material_invalid do
+    name { "" }
   end
 end

--- a/spec/requests/materials_spec.rb
+++ b/spec/requests/materials_spec.rb
@@ -1,7 +1,219 @@
 require "rails_helper"
 
 RSpec.describe "Materials", type: :request do
-  describe "GET /index" do
-    pending "add some examples (or delete) #{__FILE__}"
+  before do
+    @user = FactoryBot.create(:user) # ユーザー
+    @admin = FactoryBot.create(:user, user_type: "admin") # 管理者
+  end
+
+  describe "GET #new" do
+    subject { get(new_material_path) }
+
+    context "未ログインユーザーの場合" do
+      it "リダイレクトする" do
+        subject
+        expect(response).to have_http_status(:found)
+        expect(response).to redirect_to root_path
+        expect(flash[:alert]).to eq("不正なアクセスです")
+      end
+    end
+
+    context "ユーザーが管理者でない場合" do
+      it "リダイレクトする" do
+        sign_in @user
+        subject
+        expect(response).to have_http_status(:found)
+        expect(response).to redirect_to root_path
+        expect(flash[:alert]).to eq("不正なアクセスです")
+      end
+    end
+
+    context "ユーザーが管理者の場合" do
+      it "リスクエストが成功する" do
+        sign_in @admin
+        subject
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
+
+  describe "POST #create" do
+    subject { post(materials_path, params: material_params) }
+
+    let(:content) { create(:content) }
+    let(:material_params) { { material: attributes_for(:material, content_id: content.id) } }
+
+    context "未ログインユーザの場合" do
+      it "コンテンツの件数が変化しないこと" do
+        expect { subject }.to change { Material.count }.by(0)
+        expect(response).to have_http_status(:found)
+        expect(response).to redirect_to root_path
+        expect(flash[:alert]).to eq("不正なアクセスです")
+      end
+    end
+
+    context "ユーザーが管理者でない場合" do
+      it "コンテンツの件数が変化しないこと" do
+        sign_in @user
+        expect { subject }.to change { Material.count }.by(0)
+        expect(response).to have_http_status(:found)
+        expect(response).to redirect_to root_path
+        expect(flash[:alert]).to eq("不正なアクセスです")
+      end
+    end
+
+    context "ユーザーが管理者の場合" do
+      context "パラメータが正常な時" do
+        it "コンテンツの件数が1件増加すること" do
+          sign_in @admin
+          expect { subject }.to change { Material.count }.by(1)
+          expect(response).to have_http_status(:found)
+          expect(response).to redirect_to content_show_path(Material.last.content)
+          expect(flash[:notice]).to eq("材料を追加しました")
+        end
+      end
+
+      context "パラメータが異常な時" do
+        let(:material_params) { { material: attributes_for(:material, :material_invalid, content_id: content.id) } }
+        it "コンテンツの件数が増加しないこと" do
+          sign_in @admin
+          expect { subject }.to change { Material.count }.by(0)
+          expect(response).to have_http_status(:ok)
+          # TODO: エラーメッセージが表示されること
+          # expect(response.body).to include "を入力してください"
+        end
+      end
+    end
+  end
+
+  describe "PUT #update" do
+    subject { patch(material_path(material.id), params: material_params) }
+
+    let(:content) { create(:content) }
+    let(:content_id) { content.id }
+    let(:material) { create(:material, content_id: content_id) }
+    let(:material_params) { { material: attributes_for(:material, content_id: content_id) } }
+
+    context "未ログインユーザーの場合" do
+      it "リダイレクトすること" do
+        subject
+        expect(response).to have_http_status(:found)
+        expect(response).to redirect_to root_path
+        expect(flash[:alert]).to eq("不正なアクセスです")
+      end
+    end
+
+    context "ユーザーが管理者でない場合" do
+      it "リダイレクトすること" do
+        sign_in @user
+        subject
+        expect(response).to have_http_status(:found)
+        expect(response).to redirect_to root_path
+        expect(flash[:alert]).to eq("不正なアクセスです")
+      end
+    end
+
+    context "ユーザーが管理者の場合" do
+      context "パラメータが正常な時" do
+        it "材料が更新されること" do
+          sign_in @admin
+          new_material = material_params[:material]
+          expect { subject }.to change { material.reload.name }.from(material.name).to(new_material[:name]).
+                                  and change { material.reload.amount }.from(material.amount).to(new_material[:amount]).
+                                        and change { material.reload.unit }.from(material.unit).to(new_material[:unit])
+          expect(response).to have_http_status(:found)
+          expect(response).to redirect_to content_show_path(material.content)
+          expect(flash[:notice]).to eq("材料を更新しました")
+        end
+      end
+
+      context "パラメータが異常な時" do
+        let(:material_params) { { material: attributes_for(:material, :material_invalid, content_id: content.id) } }
+
+        it "材料が更新できないこと" do
+          sign_in @admin
+          expect { subject }.not_to change { material.reload.name }
+          expect { subject }.not_to change { material.reload.amount }
+          expect { subject }.not_to change { material.reload.unit }
+          expect(response).to have_http_status(:ok)
+          # TODO: エラーメッセージが表示されること
+          # expect(response.body).to include "を入力してください"
+        end
+      end
+    end
+  end
+
+  describe "GET #edit" do
+    subject { get(edit_material_path(material_id, content_id: content.id)) }
+
+    let(:content) { create(:content) }
+    let(:material) { create(:material, content_id: content.id) }
+    let(:material_id) { material.id }
+
+    context "未ログインユーザーの場合" do
+      it "リダイレクトされること" do
+        subject
+        expect(response).to have_http_status(:found)
+        expect(response).to redirect_to root_path
+        expect(flash[:alert]).to eq("不正なアクセスです")
+      end
+    end
+
+    context "ユーザーが管理者でない場合" do
+      it "リダイレクトされること" do
+        sign_in @user
+        subject
+        expect(response).to have_http_status(:found)
+        expect(response).to redirect_to root_path
+        expect(flash[:alert]).to eq("不正なアクセスです")
+      end
+    end
+
+    context "ユーザーが管理者の場合" do
+      it "指定したidの「材料」が表示されること" do
+        sign_in @admin
+        subject
+        expect(response.body).to include material.name
+        expect(response.body).to include material.amount.to_s
+        expect(response.body).to include material.unit
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
+
+  describe "GET #destroy" do
+    subject { delete(material_path(@material.id)) }
+
+    let(:content) { create(:content) }
+    before { @material = create(:material, content_id: content.id) }
+
+    context "未ログインユーザーの場合" do
+      it "リダイレクトされること" do
+        expect { subject }.to change { Material.count }.by(0)
+        expect(response).to have_http_status(:found)
+        expect(response).to redirect_to root_path
+        expect(flash[:alert]).to eq("不正なアクセスです")
+      end
+    end
+
+    context "ユーザーが管理者でない場合" do
+      it "リダイレクトされること" do
+        sign_in @user
+        expect { subject }.to change { Material.count }.by(0)
+        expect(response).to have_http_status(:found)
+        expect(response).to redirect_to root_path
+        expect(flash[:alert]).to eq("不正なアクセスです")
+      end
+    end
+
+    context "ユーザーが管理者の場合" do
+      it "コンテンツが削除されること" do
+        sign_in @admin
+        expect { subject }.to change { Material.count }.by(-1)
+        expect(response).to have_http_status(:found)
+        expect(response).to redirect_to content_show_path(@material.content)
+        expect(flash[:alert]).to eq("材料を削除しました")
+      end
+    end
   end
 end


### PR DESCRIPTION
## 実装の目的と概要
- Materialのリクエストスペックを実装

## 実装内容(技術的な点を記載)
- [x] Materialのリクエストスペックを実装
- [x] Make,Contentのテストを一部追加・修正
- [x] テストデータに`xxx_invalid`を追加

## 重点的に見てほしいところ(不安なところ)
- テストが通るか
 
## 確認用コマンド
```
 rspec spec/requests/materials_spec.rb
```

## 参考資料
- [RailsのRspecを書いてたらFactoryBotがハマった話](https://qiita.com/uriuribobo/items/0df452eed8ce651c1642#%E5%8E%9F%E5%9B%A0%E8%AA%BF%E6%9F%BB)
- [Faker::Number](https://github.com/faker-ruby/faker/blob/master/doc/default/number.md)


## チェックリスト

- [ ] ローカル環境での動作確認をしたか（影響し得る範囲も含めて）
- [ ] rubocopを実行して警告が出力されていないか
- [ ] GitHub で ファイル差分（Files changed）を確認し、内容が合っているか。不要なファイルに差分がでていないか
- [ ] テストでエラーが発生していないか

## 備考（実装していないことなど）
- [ ] 
