### PR TITLE
[機能開発]アカウント編集ページ・パスワード再設定ページの実装

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,14 +8,14 @@ class ApplicationController < ActionController::Base
     redirect_to root_path, alert: "不正なアクセスです" and return unless current_user.admin? # ログインユーザーが管理者か
   end
 
-  # TODO: 入力箇所を検討すること
   before_action :configure_permitted_parameters, if: :devise_controller?
 
-  # TODO: 入力箇所を検討すること
-  protected
+  private
 
-    # 新規登録用ストロングパラメータ
     def configure_permitted_parameters
+      # 新規登録用ストロングパラメータ
       devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
+      # アカウント編集用ストロングパラメータ
+      devise_parameter_sanitizer.permit(:account_update, keys: [:name])
     end
 end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -38,25 +38,28 @@ class Users::RegistrationsController < Devise::RegistrationsController
   #   super
   # end
 
-  # protected
+  protected
 
-  # If you have extra params to permit, append them to the sanitizer.
-  # def configure_sign_up_params
-  #   devise_parameter_sanitizer.permit(:sign_up, keys: [:attribute])
-  # end
+    # If you have extra params to permit, append them to the sanitizer.
+    # def configure_sign_up_params
+    #   devise_parameter_sanitizer.permit(:sign_up, keys: [:attribute])
+    # end
 
-  # If you have extra params to permit, append them to the sanitizer.
-  # def configure_account_update_params
-  #   devise_parameter_sanitizer.permit(:account_update, keys: [:attribute])
-  # end
+    # If you have extra params to permit, append them to the sanitizer.
+    # def configure_account_update_params
+    #   devise_parameter_sanitizer.permit(:account_update, keys: [:attribute])
+    # end
 
-  # The path used after sign up.
-  # def after_sign_up_path_for(resource)
-  #   super(resource)
-  # end
+    # def after_sign_up_path_for(resource)
+    #   super(resource)
+    # end
 
-  # The path used after sign up for inactive accounts.
-  # def after_inactive_sign_up_path_for(resource)
-  #   super(resource)
-  # end
+    # def after_inactive_sign_up_path_for(resource)
+    #   super(resource)
+    # end
+
+     # アカウント編集後のリダイレクト先
+    def after_update_path_for(resource)
+      mypage_path(current_user)
+    end
 end

--- a/app/views/users/passwords/new.html.erb
+++ b/app/views/users/passwords/new.html.erb
@@ -1,4 +1,4 @@
-<h2>Forgot your password?</h2>
+<h2>パスワード再設定</h2>
 
 <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
   <%= render "users/shared/error_messages", resource: resource %>
@@ -9,7 +9,7 @@
   </div>
 
   <div class="actions">
-    <%= f.submit "Send me reset password instructions" %>
+    <%= f.submit "メールを送信する" %>
   </div>
 <% end %>
 

--- a/app/views/users/registrations/edit.html.erb
+++ b/app/views/users/registrations/edit.html.erb
@@ -1,7 +1,15 @@
-<h2>Edit <%= resource_name.to_s.humanize %></h2>
+<%# TODO: ルーディングを調整すること%>
+
+<h2>アカウント編集</h2>
+<%= link_to "戻る", :back %>
 
 <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
   <%= render "users/shared/error_messages", resource: resource %>
+  
+  <div class="field">
+    <%= f.label :name %><br />
+    <%= f.text_field :name %>
+  </div>
 
   <div class="field">
     <%= f.label :email %><br />
@@ -13,31 +21,31 @@
   <% end %>
 
   <div class="field">
-    <%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br />
+    <%= f.label "新しいパスワード【変更する場合は入力】" %><br />
+    <%#= f.label :password %><!-- <br /> -->
     <%= f.password_field :password, autocomplete: "new-password" %>
-    <% if @minimum_password_length %>
-      <br />
-      <em><%= @minimum_password_length %> characters minimum</em>
-    <% end %>
   </div>
 
   <div class="field">
-    <%= f.label :password_confirmation %><br />
+    <%= f.label "新しいパスワード(確認用)【変更する場合は入力】" %><br />
+    <%#= f.label :password_confirmation %><!-- <br /> -->
     <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
   </div>
 
   <div class="field">
-    <%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />
+    <%#= f.label :current_password %><!-- <br /> -->
+    <%# TODO: 必須のマークを変更したい %>
+    <%= f.label "現在のパスワード【必須】" %><br />
     <%= f.password_field :current_password, autocomplete: "current-password" %>
   </div>
 
   <div class="actions">
-    <%= f.submit "Update" %>
+    <%= f.submit "確定する" %>
+    <%#= f.submit "Update" %>
   </div>
 <% end %>
 
-<h3>Cancel my account</h3>
+<%# アカウント削除ボタンを導入する場合は以下をコメントアウト %>
+<%#= button_to "このアカウント削除", registration_path(resource_name), data: { confirm: "アカウントを削除しますか？" }, method: :delete %>
+<%#= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete %>
 
-<p>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete %></p>
-
-<%= link_to "Back", :back %>

--- a/app/views/users/shared/_links.html.erb
+++ b/app/views/users/shared/_links.html.erb
@@ -7,9 +7,10 @@
   <%= link_to "新規作成", new_registration_path(resource_name) %><br />
 <% end %>
 
-<%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
-  <%= link_to "パスワードの再設定", new_password_path(resource_name) %><br />
-<% end %>
+<%# TODO: メール送信機能実装時に実装する %>
+<%#- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
+  <%#= link_to "パスワードの再設定", new_password_path(resource_name) %><!--<br />-->
+<%# end %>
 
 <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
   <%= link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name) %><br />

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -11,7 +11,7 @@
 </div>
 
 <div>
-  <%= link_to "アカウント編集",edit_user_registration_path(current_user) %>
+  <%= link_to "アカウント編集", edit_user_registration_path(current_user) %>
 </div>
 
 <div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -11,7 +11,7 @@
 </div>
 
 <div>
-  <%= link_to "アカウント編集",new_content_path %>
+  <%= link_to "アカウント編集",edit_user_registration_path(current_user) %>
 </div>
 
 <div>


### PR DESCRIPTION
## 実装の目的と概要
- アカウント編集ページの実装
- パスワード再設定ページの実装

## 実装内容(技術的な点を記載)
- [x] アカウント編集ページの実装
- [x] アカウント編集後の遷移先を指定

```rb
#アカウント編集後のリダイレクト先
def after_update_path_for(resource)
  リダイレクト先のパス
end
```
- [x] アカウント編集用のストロングパラメータを追加

```rb
def configure_permitted_parameters
  # 新規登録時にnicknameの取得を許可
  devise_parameter_sanitizer.permit(:sign_up, keys: [:nickname])
  # 情報更新時にnicknameの取得を許可
  devise_parameter_sanitizer.permit(:account_update, keys: [:nickname])
end
```
- [x] パスワード再設定ページの実装
- [x] パスワード再設定ページへの遷移リンクを一時非表示


## スクリーンショット（画面レイアウトを変更した場合）
![スクリーンショット 2021-05-28 13 26 50](https://user-images.githubusercontent.com/64491435/119929484-92a35f00-bfb8-11eb-829d-b71dcd54b284.png)
![スクリーンショット 2021-05-28 13 27 02](https://user-images.githubusercontent.com/64491435/119929486-93d48c00-bfb8-11eb-9367-2bb1efd16631.png)


## 参考資料
- [【Rails/devise】アカウント情報編集機能の実装/リダイレクト先の変更手順](https://qiita.com/saitok_7/items/ae7c57e26037115ed2fc)
## チェックリスト

- [x] ローカル環境での動作確認をしたか（影響し得る範囲も含めて）
- [x] rubocopを実行して警告が出力されていないか
- [x] GitHub で ファイル差分（Files changed）を確認し、内容が合っているか。不要なファイルに差分がでていないか
- [x] テストでエラーが発生していないか

## 備考（実装していないことなど）
- パスワード再設定ページは、メール送信機能を実装後に実装予定