### PR TITLE
[機能開発]Questionのリクエストスペックを実装 

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,6 +15,11 @@ class ApplicationController < ActionController::Base
     redirect_to root_path, alert: "不正なアクセスです" and return unless current_user.admin? # ログインユーザーが管理者か
   end
 
+  def user_checker
+    redirect_to root_path, alert: "不正なアクセスです" and return unless user_signed_in? # ログインしているか
+    redirect_to root_path, alert: "管理者はこの操作を行うことができません" and return unless current_user.general? # ログインユーザーが一般ユーザーか
+  end
+
   private
 
     def configure_permitted_parameters

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -1,8 +1,8 @@
 class QuestionsController < ApplicationController
+  before_action :admin_checker, only: %i[destroy]
+  before_action :user_checker, only: %i[create]
   before_action :authenticate_user!, only: %i[create destroy]
   before_action :set_question, only: %i[destroy]
-
-  # 質問できるのは、ログインユーザーのみ
 
   def index
     # 質問一覧画面
@@ -20,7 +20,7 @@ class QuestionsController < ApplicationController
 
   def destroy
     @question.destroy!
-    redirect_to content_show_path(@question.content.id), alert: "質問をを削除しました"
+    redirect_to content_show_path(@question.content.id), alert: "質問を削除しました"
   end
 
   private

--- a/spec/factories/questions.rb
+++ b/spec/factories/questions.rb
@@ -5,4 +5,8 @@ FactoryBot.define do
     question_content { Faker::Lorem.characters(number: 100) }
     status { 0 }
   end
+
+  trait :question_invalid do
+    question_content { "" }
+  end
 end

--- a/spec/requests/questions_spec.rb
+++ b/spec/requests/questions_spec.rb
@@ -1,7 +1,101 @@
 require "rails_helper"
 
 RSpec.describe "Questions", type: :request do
-  describe "GET /index" do
-    pending "add some examples (or delete) #{__FILE__}"
+  before do
+    @user = FactoryBot.create(:user) # ユーザー
+    @admin = FactoryBot.create(:user, user_type: "admin") # 管理者
+  end
+
+  # describe "GET #index" do
+  #   xit "質問一覧画面" do
+  #   end
+  # end
+
+  describe "POST #create" do
+    subject { post(questions_path, params: question_params) }
+
+    let(:question_params) { { question: attributes_for(:question) } }
+
+    context "未ログインユーザの場合" do
+      it "質問の件数が変化しないこと" do
+        expect { subject }.to change { Question.count }.by(0)
+        expect(response).to have_http_status(:found)
+        expect(response).to redirect_to root_path
+        expect(flash[:alert]).to eq("不正なアクセスです")
+      end
+    end
+
+    # Question#newから送信されていないからエラーが発生しているっぽい
+    context "一般ユーザーの場合" do
+      context "パラメータが正常な時" do
+        let(:content) { create(:content) }
+        let(:question_params) { { question: attributes_for(:question, content_id: content.id) } }
+        it "質問の件数が1件増加すること" do
+          sign_in @user
+          expect { subject }.to change { Question.count }.by(1)
+          expect(response).to have_http_status(:found)
+          expect(response).to redirect_to content_show_path(Question.last.content.id)
+          expect(flash[:notice]).to eq("質問を作成しました。返信をお待ちください。")
+        end
+      end
+
+      context "パラメータが異常な時" do
+        let(:question_params) { { question: attributes_for(:question, :question_invalid, user_id: @user.id) } }
+
+        xit "質問の件数が増加しないこと" do
+          sign_in @user
+          expect { subject }.to change { Question.count }.by(0)
+          expect(response).to have_http_status(:ok)
+          # TODO: エラーメッセージが表示されること
+          # リダイレクトするか検討中
+          # expect(response.body).to include "を入力してください"
+        end
+      end
+    end
+
+    context "管理者の場合" do
+      it "質問の件数が変化しないこと" do
+        sign_in @admin
+        expect { subject }.to change { Question.count }.by(0)
+        expect(response).to have_http_status(:found)
+        expect(response).to redirect_to root_path
+        expect(flash[:alert]).to eq("管理者はこの操作を行うことができません")
+      end
+    end
+  end
+
+  describe "GET #destroy" do
+    subject { delete(question_path(@question.id)) }
+
+    before { @question = create(:question) }
+
+    context "未ログインユーザーの場合" do
+      it "リダイレクトされること" do
+        expect { subject }.to change { Question.count }.by(0)
+        expect(response).to have_http_status(:found)
+        expect(response).to redirect_to root_path
+        expect(flash[:alert]).to eq("不正なアクセスです")
+      end
+    end
+
+    context "ユーザーが管理者でない場合" do
+      it "リダイレクトされること" do
+        sign_in @user
+        expect { subject }.to change { Question.count }.by(0)
+        expect(response).to have_http_status(:found)
+        expect(response).to redirect_to root_path
+        expect(flash[:alert]).to eq("不正なアクセスです")
+      end
+    end
+
+    context "ユーザーが管理者の場合" do
+      it "質問が削除されること" do
+        sign_in @admin
+        expect { subject }.to change { Question.count }.by(-1)
+        expect(response).to have_http_status(:found)
+        expect(response).to redirect_to content_show_path(@question.content)
+        expect(flash[:alert]).to eq("質問を削除しました")
+      end
+    end
   end
 end


### PR DESCRIPTION
## 実装の目的と概要
- Questionのリクエストスペックを実装 
## 実装内容(技術的な点を記載)
- [ ] Questionのリクエストスペックを実装 

 ## 確認用コマンド
```
rspec spec/request
```

## チェックリスト

- [x] ローカル環境での動作確認をしたか（影響し得る範囲も含めて）
- [x] rubocopを実行して警告が出力されていないか
- [x] GitHub で ファイル差分（Files changed）を確認し、内容が合っているか。不要なファイルに差分がでていないか
- [x] テストでエラーが発生していないか

## 備考（実装していないことなど）
createの例外処理は、ペツページにあるためrenderがうまくできない状態。候補としては、以下の2つを検討中
- 1.content#showでrenderするために必要な情報を全て渡す
- 2.renderではなく、redirect_toにして、再度入力を促す。ただし、最低限のフロントバリデージョン を実装した上で実装予定。