### PR TITLE
[update]モデルスペックの境界値テストを修正/文言の修正

### DIFF
--- a/spec/features/contents_spec.rb
+++ b/spec/features/contents_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe "Contents", type: :feature do
       end
     end
 
-    context "ユーザーが管理者の場合" do
+    context "管理者の場合" do
       it "新規作成リンクが表示されること" do
         sign_in @admin
         visit content_show_path(@content.id)

--- a/spec/models/content_spec.rb
+++ b/spec/models/content_spec.rb
@@ -20,7 +20,14 @@ RSpec.describe Content, type: :model do
         end
       end
 
-      context "16文字以上の場合" do
+      context "16文字の場合" do
+        let(:content) { build(:content, title: "1" * 16) }
+        it "保存ができる" do
+          expect(subject).to eq true
+        end
+      end
+
+      context "17文字の場合" do
         let(:content) { build(:content, title: "1" * 17) }
         it "保存ができない" do
           expect(subject).to eq false
@@ -37,7 +44,14 @@ RSpec.describe Content, type: :model do
           end
         end
 
-        context "32文字以上の場合" do
+        context "32文字の場合" do
+          let(:content) { build(:content, subtitle: "1" * 16) }
+          it "保存ができる" do
+            expect(subject).to eq true
+          end
+        end
+
+        context "33文字の場合" do
           let(:content) { build(:content, subtitle: "1" * 33) }
           it "保存ができない" do
             expect(subject).to eq false
@@ -55,7 +69,14 @@ RSpec.describe Content, type: :model do
           end
         end
 
-        context "32文字以上の場合" do
+        context "32文字の場合" do
+          let(:content) { build(:content, comment: "1" * 32) }
+          it "保存ができる" do
+            expect(subject).to eq true
+          end
+        end
+
+        context "33文字の場合" do
           let(:content) { build(:content, comment: "1" * 33) }
           it "保存ができない" do
             expect(subject).to eq false
@@ -73,7 +94,14 @@ RSpec.describe Content, type: :model do
           end
         end
 
-        context "32文字以上の場合" do
+        context "32文字の場合" do
+          let(:content) { build(:content, point: "1" * 32) }
+          it "保存ができる" do
+            expect(subject).to eq true
+          end
+        end
+
+        context "33文字以上の場合" do
           let(:content) { build(:content, point: "1" * 33) }
           it "保存ができない" do
             expect(subject).to eq false

--- a/spec/models/make_spec.rb
+++ b/spec/models/make_spec.rb
@@ -20,7 +20,14 @@ RSpec.describe Make, type: :model do
         end
       end
 
-      context "32文字以上の場合" do
+      context "32文字の場合" do
+        let(:make) { build(:make, detail: "1" * 32) }
+        it "保存ができる" do
+          expect(subject).to eq true
+        end
+      end
+
+      context "33文字の場合" do
         let(:make) { build(:make, detail: "1" * 33) }
         it "保存ができない" do
           expect(subject).to eq false

--- a/spec/models/material_spec.rb
+++ b/spec/models/material_spec.rb
@@ -20,7 +20,14 @@ RSpec.describe Material, type: :model do
         end
       end
 
-      context "16文字以上の場合" do
+      context "16文字の場合" do
+        let(:material) { build(:material, name: "1" * 16) }
+        it "保存ができる" do
+          expect(subject).to eq true
+        end
+      end
+
+      context "17文字の場合" do
         let(:material) { build(:material, name: "1" * 17) }
         it "保存ができない" do
           expect(subject).to eq false
@@ -38,7 +45,14 @@ RSpec.describe Material, type: :model do
         end
       end
 
-      context "5文字以上の場合" do
+      context "5文字の場合" do
+        let(:material) { build(:material, amount: "1" * 5) }
+        it "保存ができる" do
+          expect(subject).to eq true
+        end
+      end
+
+      context "6文字の場合" do
         let(:material) { build(:material, amount: "1" * 6) }
         it "エラーが出力される" do
           expect(subject).to eq false
@@ -48,7 +62,6 @@ RSpec.describe Material, type: :model do
 
       context "数字以外の場合" do
         let(:material) { build(:material, amount: "a" * 5) }
-
         it "エラーが出力される" do
           expect(subject).to eq false
           expect(material.errors.messages[:amount]).to include "は数値で入力してください"
@@ -65,7 +78,14 @@ RSpec.describe Material, type: :model do
         end
       end
 
-      context "5文字以上の場合" do
+      context "5文字の場合" do
+        let(:material) { build(:material, unit: "1" * 5) }
+        it "保存ができる" do
+          expect(subject).to eq true
+        end
+      end
+
+      context "6文字の場合" do
         let(:material) { build(:material, unit: "1" * 6) }
         it "保存ができない" do
           expect(subject).to eq false

--- a/spec/models/question_spec.rb
+++ b/spec/models/question_spec.rb
@@ -20,7 +20,14 @@ RSpec.describe Question, type: :model do
         end
       end
 
-      context "100文字以上の場合" do
+      context "100文字の場合" do
+        let(:question) { build(:question, question_content: "1" * 100) }
+        it "保存ができる" do
+          expect(subject).to eq true
+        end
+      end
+
+      context "101文字の場合" do
         let(:question) { build(:question, question_content: "1" * 101) }
         it "保存ができない" do
           expect(subject).to eq false

--- a/spec/models/response_spec.rb
+++ b/spec/models/response_spec.rb
@@ -20,7 +20,14 @@ RSpec.describe Response, type: :model do
         end
       end
 
-      context "100文字以上の場合" do
+      context "100文字の場合" do
+        let(:response) { build(:response, response_content: "1" * 100) }
+        it "保存ができる" do
+          expect(subject).to eq true
+        end
+      end
+
+      context "101文字の場合" do
         let(:response) { build(:response, response_content: "1" * 101) }
         it "保存ができない" do
           expect(subject).to eq false

--- a/spec/models/review_spec.rb
+++ b/spec/models/review_spec.rb
@@ -20,7 +20,14 @@ RSpec.describe Review, type: :model do
         end
       end
 
-      context "500文字以上の場合" do
+      context "500文字の場合" do
+        let(:review) { build(:review, comment: "1" * 500) }
+        it "保存ができる" do
+          expect(subject).to eq true
+        end
+      end
+
+      context "501文字の場合" do
         let(:review) { build(:review, comment: "1" * 501) }
         it "保存ができない" do
           expect(subject).to eq false

--- a/spec/requests/categories_spec.rb
+++ b/spec/requests/categories_spec.rb
@@ -33,14 +33,14 @@ RSpec.describe "Categories", type: :request do
   #       end
   #     end
 
-  #     context "ユーザーが管理者でない場合" do
+  #     context "一般ユーザーの場合" do
   #       xit "新規登録ボタンが表示されない" do
   #         sign_in @admin
   #         # 表示されない処理
   #       end
   #     end
 
-  #     context "ユーザーが管理者の場合" do
+  #     context "管理者の場合" do
   #       xit "新規登録ボタンが表示される" do
   #         sign_in @user
   #         # 表示される処理
@@ -61,7 +61,7 @@ RSpec.describe "Categories", type: :request do
       end
     end
 
-    context "ユーザーが管理者でない場合" do
+    context "一般ユーザーの場合" do
       it "リダイレクトする" do
         sign_in @user
         subject
@@ -70,7 +70,7 @@ RSpec.describe "Categories", type: :request do
         expect(flash[:alert]).to eq("不正なアクセスです")
       end
 
-      context "ユーザーが管理者の場合" do
+      context "管理者の場合" do
         it "リスクエストが成功する" do
           sign_in @admin
           subject
@@ -110,14 +110,14 @@ RSpec.describe "Categories", type: :request do
         end
       end
 
-      context "ユーザーが管理者でない場合" do
+      context "一般ユーザーの場合" do
         xit "xxボタンが表示されないこと" do
           sign_in @user
           # テスト
         end
       end
 
-      context "ユーザーが管理者の場合" do
+      context "管理者の場合" do
         xit "xxボタンが表示されること" do
           sign_in @admin
           # テスト
@@ -140,7 +140,7 @@ RSpec.describe "Categories", type: :request do
       end
     end
 
-    context "ユーザーが管理者でない場合" do
+    context "一般ユーザーの場合" do
       it "カテゴリーの件数が変化しないこと" do
         sign_in @user
         expect { subject }.to change { Category.count }.by(0)
@@ -150,7 +150,7 @@ RSpec.describe "Categories", type: :request do
       end
     end
 
-    context "ユーザーが管理者の場合" do
+    context "管理者の場合" do
       context "パラメータが正常な時" do
         it "カテゴリーの件数が1件増加すること" do
           sign_in @admin
@@ -189,7 +189,7 @@ RSpec.describe "Categories", type: :request do
         end
       end
 
-      context "ユーザーが管理者でない場合" do
+      context "一般ユーザーの場合" do
         it "リダイレクトすること" do
           sign_in @user
           subject
@@ -199,7 +199,7 @@ RSpec.describe "Categories", type: :request do
         end
       end
 
-      context "ユーザーが管理者の場合"
+      context "管理者の場合"
       context "パラメータが正常な時" do
         it "カテゴリーが更新されること" do
           sign_in @admin
@@ -240,7 +240,7 @@ RSpec.describe "Categories", type: :request do
       end
     end
 
-    context "ユーザーが管理者でない場合" do
+    context "一般ユーザーの場合" do
       it "リダイレクトされること" do
         sign_in @user
         subject
@@ -250,7 +250,7 @@ RSpec.describe "Categories", type: :request do
       end
     end
 
-    context "ユーザーが管理者の場合" do
+    context "管理者の場合" do
       it "指定したidのカテゴリーが表示されること" do
         sign_in @admin
         subject
@@ -274,7 +274,7 @@ RSpec.describe "Categories", type: :request do
       end
     end
 
-    context "ユーザーが管理者でない場合" do
+    context "一般ユーザーの場合" do
       it "リダイレクトされること" do
         sign_in @user
         expect { subject }.to change { Category.count }.by(0)
@@ -284,7 +284,7 @@ RSpec.describe "Categories", type: :request do
       end
     end
 
-    context "ユーザーが管理者の場合" do
+    context "管理者の場合" do
       it "カテゴリーが削除されること" do
         sign_in @admin
         expect { subject }.to change { Category.count }.by(-1)

--- a/spec/requests/contents_spec.rb
+++ b/spec/requests/contents_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe "Contents", type: :request do
       end
     end
 
-    context "ユーザーが管理者でない場合" do
+    context "一般ユーザーの場合" do
       it "リダイレクトする" do
         sign_in @user
         subject
@@ -46,7 +46,7 @@ RSpec.describe "Contents", type: :request do
         expect(flash[:alert]).to eq("不正なアクセスです")
       end
 
-      context "ユーザーが管理者の場合" do
+      context "管理者の場合" do
         it "リスクエストが成功する" do
           sign_in @admin
           subject
@@ -99,7 +99,7 @@ RSpec.describe "Contents", type: :request do
       end
     end
 
-    context "ユーザーが管理者でない場合" do
+    context "一般ユーザーの場合" do
       it "コンテンツの件数が変化しないこと" do
         sign_in @user
         expect { subject }.to change { Content.count }.by(0)
@@ -109,7 +109,7 @@ RSpec.describe "Contents", type: :request do
       end
     end
 
-    context "ユーザーが管理者の場合" do
+    context "管理者の場合" do
       context "パラメータが正常な時" do
         it "コンテンツの件数が1件増加すること" do
           sign_in @admin
@@ -148,7 +148,7 @@ RSpec.describe "Contents", type: :request do
         end
       end
 
-      context "ユーザーが管理者でない場合" do
+      context "一般ユーザーの場合" do
         it "リダイレクトすること" do
           sign_in @user
           subject
@@ -158,7 +158,7 @@ RSpec.describe "Contents", type: :request do
         end
       end
 
-      context "ユーザーが管理者の場合"
+      context "管理者の場合"
       context "パラメータが正常な時" do
         it "コンテンツが更新されること" do
           sign_in @admin
@@ -203,7 +203,7 @@ RSpec.describe "Contents", type: :request do
       end
     end
 
-    context "ユーザーが管理者でない場合" do
+    context "一般ユーザーの場合" do
       it "リダイレクトされること" do
         sign_in @user
         subject
@@ -213,7 +213,7 @@ RSpec.describe "Contents", type: :request do
       end
     end
 
-    context "ユーザーが管理者の場合" do
+    context "管理者の場合" do
       it "指定したidのコンテンツが表示されること" do
         sign_in @admin
         subject
@@ -241,7 +241,7 @@ RSpec.describe "Contents", type: :request do
       end
     end
 
-    context "ユーザーが管理者でない場合" do
+    context "一般ユーザーの場合" do
       it "リダイレクトされること" do
         sign_in @user
         expect { subject }.to change { Content.count }.by(0)
@@ -251,7 +251,7 @@ RSpec.describe "Contents", type: :request do
       end
     end
 
-    context "ユーザーが管理者の場合" do
+    context "管理者の場合" do
       it "コンテンツが削除されること" do
         sign_in @admin
         expect { subject }.to change { Content.count }.by(-1)

--- a/spec/requests/makes_spec.rb
+++ b/spec/requests/makes_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "Makes", type: :request do
       end
     end
 
-    context "ユーザーが管理者でない場合" do
+    context "一般ユーザーの場合" do
       it "リダイレクトする" do
         sign_in @user
         subject
@@ -28,7 +28,7 @@ RSpec.describe "Makes", type: :request do
       end
     end
 
-    context "ユーザーが管理者の場合" do
+    context "管理者の場合" do
       it "リスクエストが成功する" do
         sign_in @admin
         subject
@@ -52,7 +52,7 @@ RSpec.describe "Makes", type: :request do
       end
     end
 
-    context "ユーザーが管理者でない場合" do
+    context "一般ユーザーの場合" do
       it "コンテンツの件数が変化しないこと" do
         sign_in @user
         expect { subject }.to change { Make.count }.by(0)
@@ -62,7 +62,7 @@ RSpec.describe "Makes", type: :request do
       end
     end
 
-    context "ユーザーが管理者の場合" do
+    context "管理者の場合" do
       context "パラメータが正常な時" do
         it "コンテンツの件数が1件増加すること" do
           sign_in @admin
@@ -103,7 +103,7 @@ RSpec.describe "Makes", type: :request do
       end
     end
 
-    context "ユーザーが管理者でない場合" do
+    context "一般ユーザーの場合" do
       it "リダイレクトすること" do
         sign_in @user
         subject
@@ -113,7 +113,7 @@ RSpec.describe "Makes", type: :request do
       end
     end
 
-    context "ユーザーが管理者の場合" do
+    context "管理者の場合" do
       context "パラメータが正常な時" do
         it "コンテンツが更新されること" do
           sign_in @admin
@@ -155,7 +155,7 @@ RSpec.describe "Makes", type: :request do
       end
     end
 
-    context "ユーザーが管理者でない場合" do
+    context "一般ユーザーの場合" do
       it "リダイレクトされること" do
         sign_in @user
         subject
@@ -165,7 +165,7 @@ RSpec.describe "Makes", type: :request do
       end
     end
 
-    context "ユーザーが管理者の場合" do
+    context "管理者の場合" do
       it "指定したidの「作り方」が表示されること" do
         sign_in @admin
         subject
@@ -190,7 +190,7 @@ RSpec.describe "Makes", type: :request do
       end
     end
 
-    context "ユーザーが管理者でない場合" do
+    context "一般ユーザーの場合" do
       it "リダイレクトされること" do
         sign_in @user
         expect { subject }.to change { Make.count }.by(0)
@@ -200,7 +200,7 @@ RSpec.describe "Makes", type: :request do
       end
     end
 
-    context "ユーザーが管理者の場合" do
+    context "管理者の場合" do
       it "コンテンツが削除されること" do
         sign_in @admin
         expect { subject }.to change { Make.count }.by(-1)

--- a/spec/requests/materials_spec.rb
+++ b/spec/requests/materials_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "Materials", type: :request do
       end
     end
 
-    context "ユーザーが管理者でない場合" do
+    context "一般ユーザーの場合" do
       it "リダイレクトする" do
         sign_in @user
         subject
@@ -28,7 +28,7 @@ RSpec.describe "Materials", type: :request do
       end
     end
 
-    context "ユーザーが管理者の場合" do
+    context "管理者の場合" do
       it "リスクエストが成功する" do
         sign_in @admin
         subject
@@ -52,7 +52,7 @@ RSpec.describe "Materials", type: :request do
       end
     end
 
-    context "ユーザーが管理者でない場合" do
+    context "一般ユーザーの場合" do
       it "コンテンツの件数が変化しないこと" do
         sign_in @user
         expect { subject }.to change { Material.count }.by(0)
@@ -62,7 +62,7 @@ RSpec.describe "Materials", type: :request do
       end
     end
 
-    context "ユーザーが管理者の場合" do
+    context "管理者の場合" do
       context "パラメータが正常な時" do
         it "コンテンツの件数が1件増加すること" do
           sign_in @admin
@@ -103,7 +103,7 @@ RSpec.describe "Materials", type: :request do
       end
     end
 
-    context "ユーザーが管理者でない場合" do
+    context "一般ユーザーの場合" do
       it "リダイレクトすること" do
         sign_in @user
         subject
@@ -113,7 +113,7 @@ RSpec.describe "Materials", type: :request do
       end
     end
 
-    context "ユーザーが管理者の場合" do
+    context "管理者の場合" do
       context "パラメータが正常な時" do
         it "材料が更新されること" do
           sign_in @admin
@@ -159,7 +159,7 @@ RSpec.describe "Materials", type: :request do
       end
     end
 
-    context "ユーザーが管理者でない場合" do
+    context "一般ユーザーの場合" do
       it "リダイレクトされること" do
         sign_in @user
         subject
@@ -169,7 +169,7 @@ RSpec.describe "Materials", type: :request do
       end
     end
 
-    context "ユーザーが管理者の場合" do
+    context "管理者の場合" do
       it "指定したidの「材料」が表示されること" do
         sign_in @admin
         subject
@@ -196,7 +196,7 @@ RSpec.describe "Materials", type: :request do
       end
     end
 
-    context "ユーザーが管理者でない場合" do
+    context "一般ユーザーの場合" do
       it "リダイレクトされること" do
         sign_in @user
         expect { subject }.to change { Material.count }.by(0)
@@ -206,7 +206,7 @@ RSpec.describe "Materials", type: :request do
       end
     end
 
-    context "ユーザーが管理者の場合" do
+    context "管理者の場合" do
       it "コンテンツが削除されること" do
         sign_in @admin
         expect { subject }.to change { Material.count }.by(-1)

--- a/spec/requests/questions_spec.rb
+++ b/spec/requests/questions_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe "Questions", type: :request do
       end
     end
 
-    context "ユーザーが管理者でない場合" do
+    context "一般ユーザーの場合" do
       it "リダイレクトされること" do
         sign_in @user
         expect { subject }.to change { Question.count }.by(0)
@@ -88,7 +88,7 @@ RSpec.describe "Questions", type: :request do
       end
     end
 
-    context "ユーザーが管理者の場合" do
+    context "管理者の場合" do
       it "質問が削除されること" do
         sign_in @admin
         expect { subject }.to change { Question.count }.by(-1)

--- a/spec/requests/responses_spec.rb
+++ b/spec/requests/responses_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "Responses", type: :request do
       end
     end
 
-    context "ユーザーが管理者でない場合" do
+    context "一般ユーザーの場合" do
       it "リダイレクトする" do
         sign_in @user
         subject
@@ -30,7 +30,7 @@ RSpec.describe "Responses", type: :request do
       end
     end
 
-    context "ユーザーが管理者の場合" do
+    context "管理者の場合" do
       it "リスクエストが成功する" do
         sign_in @admin
         subject
@@ -54,7 +54,7 @@ RSpec.describe "Responses", type: :request do
       end
     end
 
-    context "ユーザーが管理者でない場合" do
+    context "一般ユーザーの場合" do
       it "返信の件数が変化しないこと" do
         sign_in @user
         expect { subject }.to change { Response.count }.by(0)
@@ -64,7 +64,7 @@ RSpec.describe "Responses", type: :request do
       end
     end
 
-    context "ユーザーが管理者の場合" do
+    context "管理者の場合" do
       context "パラメータが正常な時" do
         it "返信の件数が1件増加すること" do
           sign_in @admin
@@ -105,7 +105,7 @@ RSpec.describe "Responses", type: :request do
       end
     end
 
-    context "ユーザーが管理者でない場合" do
+    context "一般ユーザーの場合" do
       it "リダイレクトすること" do
         sign_in @user
         subject
@@ -115,7 +115,7 @@ RSpec.describe "Responses", type: :request do
       end
     end
 
-    context "ユーザーが管理者の場合" do
+    context "管理者の場合" do
       context "パラメータが正常な時" do
         it "返信が更新されること" do
           sign_in @admin
@@ -157,7 +157,7 @@ RSpec.describe "Responses", type: :request do
       end
     end
 
-    context "ユーザーが管理者でない場合" do
+    context "一般ユーザーの場合" do
       it "リダイレクトされること" do
         sign_in @user
         subject
@@ -167,7 +167,7 @@ RSpec.describe "Responses", type: :request do
       end
     end
 
-    context "ユーザーが管理者の場合" do
+    context "管理者の場合" do
       it "指定したidの「返信」が表示されること" do
         sign_in @admin
         subject
@@ -191,7 +191,7 @@ RSpec.describe "Responses", type: :request do
       end
     end
 
-    context "ユーザーが管理者でない場合" do
+    context "一般ユーザーの場合" do
       it "リダイレクトされること" do
         sign_in @user
         expect { subject }.to change { Response.count }.by(0)
@@ -201,7 +201,7 @@ RSpec.describe "Responses", type: :request do
       end
     end
 
-    context "ユーザーが管理者の場合" do
+    context "管理者の場合" do
       it "返信が削除されること" do
         sign_in @admin
         expect { subject }.to change { Response.count }.by(-1)

--- a/spec/requests/reviews_spec.rb
+++ b/spec/requests/reviews_spec.rb
@@ -18,14 +18,14 @@ RSpec.describe "Reviews", type: :request do
       end
     end
 
-    context "ユーザーが管理者でない場合" do
+    context "一般ユーザーの場合" do
       it "リスクエストが成功する" do
         sign_in @user
         subject
         expect(response).to have_http_status(:ok)
       end
 
-      context "ユーザーが管理者の場合" do
+      context "管理者の場合" do
         it "リスクエストが成功する" do
           sign_in @admin
           subject
@@ -50,7 +50,7 @@ RSpec.describe "Reviews", type: :request do
       end
     end
 
-    context "ユーザーが管理者でない場合" do
+    context "一般ユーザーの場合" do
       context "パラメータが正常な時" do
         it "レビューの件数が1件増加すること" do
           sign_in @user
@@ -74,7 +74,7 @@ RSpec.describe "Reviews", type: :request do
     end
 
     # TODO: 検討する
-    context "ユーザーが管理者の場合" do
+    context "管理者の場合" do
       context "パラメータが正常な時" do
         it "レビューの件数が1件増加すること" do
           sign_in @admin


### PR DESCRIPTION
## 実装の目的と概要
- 境界値が曖昧だったため、モデルスペックの境界値テストを修正
- 文言の修正（管理者でない場合→一般ユーザーの場合）

## 実装内容(技術的な点を記載)
- [x] モデルスペックの境界値テストを修正
- [x] 文言の修正（管理者でない場合→一般ユーザーの場合）


## チェックリスト

- [x] ローカル環境での動作確認をしたか（影響し得る範囲も含めて）
- [x] rubocopを実行して警告が出力されていないか
- [x] GitHub で ファイル差分（Files changed）を確認し、内容が合っているか。不要なファイルに差分がでていないか
- [x] テストでエラーが発生していないか