### PR TITLE
[機能開発]質問フォームの例外処理への対応

### DIFF
--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -13,8 +13,7 @@ class QuestionsController < ApplicationController
     if @question.save
       redirect_to content_show_path(@question.content.id), notice: "質問を作成しました。返信をお待ちください。"
     else
-      # TODO: フロントバリデージョンを実装することで、renderさせないもしくはredirectさせる
-      render :new
+      redirect_to content_show_path(@question.content.id), alert: "エラーが発生しました。500文字以内で入力してください。"
     end
   end
 

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -13,7 +13,8 @@ class QuestionsController < ApplicationController
     if @question.save
       redirect_to content_show_path(@question.content.id), notice: "質問を作成しました。返信をお待ちください。"
     else
-      redirect_to content_show_path(@question.content.id), alert: "エラーが発生しました。500文字以内で入力してください。"
+      error_message = Question.question_error_message(@question)
+      redirect_to content_show_path(@question.content.id), alert: error_message.to_s
     end
   end
 

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -4,4 +4,15 @@ class Question < ApplicationRecord
   has_one :response, dependent: :destroy
 
   validates :question_content, presence: true, length: { in: 1..100, allow_blank: true }
+
+  def self.question_error_message(q)
+    case q.errors.full_messages
+    when ["Question contentを入力してください"]
+      "質問が入力されていません"
+    when ["Question contentは100文字以内で入力してください"]
+      "文字数オーバーです。100文字以内で入力してください。"
+    else
+      "予期せぬエラーが発生しました"
+    end
+  end
 end

--- a/app/views/contents/_question_form.html.erb
+++ b/app/views/contents/_question_form.html.erb
@@ -1,11 +1,10 @@
 <div>
   <%= form_with model: @question, local: true do |f| %>
-  <%= render 'layouts/error_messages', model: f.object %>
   <%= f.hidden_field :content_id, value: @content.id %>
   
   <div>
     <h2>質問</h2>
-    <p><%= f.text_area :question_content %></p>
+    <p><%= f.text_area :question_content, placeholder: "100文字以内", maxlength:"100" %></p>
   </div>
 
     <div>

--- a/spec/features/contents_spec.rb
+++ b/spec/features/contents_spec.rb
@@ -12,31 +12,6 @@ RSpec.describe "Contents", type: :feature do
     @response = create(:response, question_id: @end_question.id) # 返信
   end
 
-  describe "GET #index" do
-    context "未ログインユーザーの場合" do
-      it "新規登録リンクが表示されない" do
-        visit contents_path
-        expect(page).not_to have_link "新規作成"
-      end
-    end
-
-    context "一般ユーザーの場合" do
-      it "新規登録リンクが表示されない" do
-        sign_in @user
-        visit contents_path
-        expect(page).not_to have_link "新規作成"
-      end
-    end
-
-    context "管理者の場合" do
-      it "新規登録リンクが表示される" do
-        sign_in @admin
-        visit contents_path
-        expect(page).to have_link "新規作成", href: new_content_path
-      end
-    end
-  end
-
   describe "GET #show" do
     let(:content) { create(:content) }
 


### PR DESCRIPTION
## 実装の目的と概要
- content/showで質問を作成するときにrenderが発生した場合、エラーになる
- そのため、renderではなく、redirectで対応するように実装した。
## 実装内容(技術的な点を記載)
- [x] renderをredirectに置き換え
- [x] フォームに`maxlength`を実装
- [x] 空文字の場合のエラーメッセージを実装

## スクリーンショット（画面レイアウトを変更した場合）
<img width="838" alt="スクリーンショット 2021-06-03 21 45 04" src="https://user-images.githubusercontent.com/64491435/120649374-a585ca00-c4b7-11eb-8e9a-1bacada155f2.png">
<img width="838" alt="スクリーンショット 2021-06-03 21 45 35" src="https://user-images.githubusercontent.com/64491435/120649401-acacd800-c4b7-11eb-9a04-46f6c21e9573.png">

## チェックリスト

- [x] ローカル環境での動作確認をしたか（影響し得る範囲も含めて）
- [x] rubocopを実行して警告が出力されていないか
- [x] GitHub で ファイル差分（Files changed）を確認し、内容が合っているか。不要なファイルに差分がでていないか
- [x] テストでエラーが発生していないか