### PR TITLE
[フロント]質問と返信のレイアウトを実装

### DIFF
--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -111,7 +111,7 @@
 
 //activeの場合、固定する
 .page-active-link {
-  @apply text-white py-4 px-4  my-4 border bg-dekiru-blue
+  @apply text-white py-4 px-4 my-4 border bg-dekiru-blue
 }
 
 //1つ進む・1つ戻る

--- a/app/views/contents/_question_card.html.erb
+++ b/app/views/contents/_question_card.html.erb
@@ -1,58 +1,56 @@
-<hr>
+<div class="p-2 mb-4">
 
-<!-- 質問-->
-<div>
+  <!-- 質問-->
+  <div  class="border border-gray-300 rounded-lg mb-4">
+    <!-- 質問ユーザー -->
+    <div class="flex px-4 py-8">
+      <%= image_tag question.user.thumbnail.thumb27.url %>
+      <%= question.user.name %>
+    </div>
 
-  <!-- 質問ユーザー -->
-  <div>
-    <%= image_tag question.user.thumbnail.thumb27.url %>
-    <%= question.user.name %>
+    <!-- 質問内容 -->
+    <div class="text-left px-4 py-8">
+      <%= question.question_content %>
+    </div>
+
+    <!-- 質問CRUD -->
+    <% if question.user == current_user || admin_user? %>
+      <div class="text-left p-4">
+        <%= link_to ">>削除", question_path(question), data: { confirm: '確定します。よろしいでしょうか？'}, method: :delete, class:"red-link" %>
+      </div>
+    <% end %>
   </div>
 
-  <!-- 質問内容 -->
-  <div>
-    <%= question.question_content %>
+
+  <!--返信-->
+  <div class="border bg-gray-100 rounded-lg">
+    <% if question.response.present?%> <%# 返信がある場合、返信を表示する%>
+
+      <!-- DEKRIU情報 -->
+      <div class="flex justify-end px-4 py-8">
+        <span>deKiRU</span><!-- TODO: 少し変かもしれない。全て大文字にするか相談する -->
+        <%= image_tag @admin.thumbnail.thumb27.url %>
+      </div>
+
+      <!-- 返信内容 -->
+      <div class="text-right px-4 py-8">
+        <%= question.response.response_content %>
+      </div>
+
+      <!-- 返信CRUD -->
+      <% if admin_user? %>
+        <div class="flex justify-end p-4">
+          <div class= "px-4 mr-1 text-right"><%= link_to ">>編集", edit_response_path(question.response, question_id: question.id), class:"admin-link" %></div>
+          <div><%= link_to ">>削除", response_path(question.response), data: { confirm: '確定します。よろしいでしょうか？'}, method: :delete, class:"admin-link" %></div>
+        </div>
+      <% end %>
+
+    <% else %> <%# 返信がない場合、返信を作成するリンクを表示%>
+
+      <!-- 返信リンク -->
+      <% if admin_user? && question.response.nil? %>
+        <div><%= link_to ">>返信する", new_response_path(question_id: question.id), class:"admin-link" %></div>
+      <% end %>
+    <% end %>
   </div>
-
-  <!-- 削除リンク-->
-  <% if question.user == current_user || admin_user? %>
-    <div>
-      <%= link_to ">>削除", question_path(question), data: { confirm: '確定します。よろしいでしょうか？'}, method: :delete, class:"red-link" %>
-    </div>
-  <% end %>
-
-</div>
-
-
-<br/>
-
-<!-- 返信-->
-
-<div>
-  <% if question.response.present?%>
-    <%# 返信がある場合、返信を表示する%>
-    <!-- DEKRIU情報 -->
-    <div>
-      <span>DEKIRU</span>
-      <%= image_tag @admin.thumbnail.thumb27.url %>
-    </div>
-    <!-- 返信内容 -->
-    <div>
-      <%= question.response.response_content %>
-    </div>
-    <!-- 削除リンク -->
-    <% if admin_user? %>
-      <span><%= link_to ">>編集", edit_response_path(question.response, question_id: question.id), class:"admin-link" %></span>
-      <span><%= link_to ">>削除", response_path(question.response), data: { confirm: '確定します。よろしいでしょうか？'}, method: :delete, class:"admin-link" %></span>
-    <% end %>
-
-  <% else %>
-    <%# 返信がない場合、返信を作成するリンクを表示%>
-    <!-- 返信リンク -->
-    <% if admin_user? && question.response.nil? %>
-      <span><%= link_to ">>返信する", new_response_path(question_id: question.id), class:"admin-link" %></span>
-    <% end %>
-
-  <% end %>
-
 </div>


### PR DESCRIPTION
## 実装の目的と概要
- 質問と返信のレイアウトを実装

## 実装内容(技術的な点を記載)
- [x] 質問と返信のレイアウトを実装
 

## スクリーンショット（画面レイアウトを変更した場合）
<img width="840" alt="スクリーンショット 2021-06-06 13 20 46" src="https://user-images.githubusercontent.com/64491435/120912481-69768300-c6ca-11eb-89b3-12a56956895c.png">
<img width="1680" alt="スクリーンショット 2021-06-06 13 22 00" src="https://user-images.githubusercontent.com/64491435/120912491-87dc7e80-c6ca-11eb-99fd-7cf234dc5124.png">


## チェックリスト

- [x] ローカル環境での動作確認をしたか（影響し得る範囲も含めて）
- [x] rubocopを実行して警告が出力されていないか
- [x] GitHub で ファイル差分（Files changed）を確認し、内容が合っているか。不要なファイルに差分がでていないか
- [x] テストでエラーが発生していないか
