### PR TITLE
[レイアウト]コンテンツの表示を修正

### DIFF
--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -8,7 +8,7 @@
 }
 
 .h2 {
-  @apply text-2xl text-dekiru-font font-medium py-2
+  @apply text-2xl text-dekiru-font font-medium
 }
 
 //************ボタン**************//
@@ -103,6 +103,11 @@
   @apply border w-full py-8 focus:outline-none focus:border-gray-500 focus:bg-gray-100 
 }
 
+
+//************ コンテンツ  **************//
+.content-style {
+  @apply md:flex justify-center flex-wrap mb-16
+}
 
 //************ ページネーション  **************//
 .page-link {

--- a/app/views/categories/edit.html.erb
+++ b/app/views/categories/edit.html.erb
@@ -1,4 +1,4 @@
-<h2 class="h2">カテゴリー編集</h2>
+<h2 class="h2 py-8">カテゴリー編集</h2>
 
 <%= link_to "カテゴリー一覧へ戻る", categories_path %>
 

--- a/app/views/categories/index.html.erb
+++ b/app/views/categories/index.html.erb
@@ -1,5 +1,5 @@
 <div class="my-8">
-  <h2 class="h2">カテゴリー一覧画面</h2>
+  <h2 class="h2 py-8">カテゴリー一覧画面</h2>
   <div class="pt-16 pb-32">
     <div class="flex justify-start flex-wrap my-2">
       <%= render partial: "category_card", collection: @categories, as: "category" %>

--- a/app/views/categories/new.html.erb
+++ b/app/views/categories/new.html.erb
@@ -1,4 +1,4 @@
-<h2 class="h2">カテゴリー作成</h2>
+<h2 class="h2 py-8">カテゴリー作成</h2>
 
 <%= link_to "カテゴリー一覧へ戻る", categories_path %>
 

--- a/app/views/categories/show.html.erb
+++ b/app/views/categories/show.html.erb
@@ -1,7 +1,7 @@
-<h1><%= @category.name%><h1>
-
-<%= render partial: "layouts/content_card", collection: @contents, as: "content" %>
-
+<h2 class="h2 py-8"><%= @category.name%><h2>
+<div class="content-style">
+  <%= render partial: "layouts/content_card", collection: @contents, as: "content" %>
+</div>
 <!-- ページネーション -->
 <%= paginate @contents, window: 1 %>
 <div class="py-4">

--- a/app/views/contents/index.html.erb
+++ b/app/views/contents/index.html.erb
@@ -1,7 +1,7 @@
-<h2 class="h2">コンテンツ一覧</h2>
+<h2 class="h2 py-8">コンテンツ一覧</h2>
 
 <!-- content_card -->
-<div class="md:flex justify-center">
+<div class="content-style">
   <%= render partial: "layouts/content_card", collection: @contents, as: "content" %>
 </div>
 

--- a/app/views/contents/newest.html.erb
+++ b/app/views/contents/newest.html.erb
@@ -1,6 +1,7 @@
-<h1>新着情報一覧</h1>
-
-<%= render partial: "layouts/content_card", collection: @new_contents, as: "content" %>
+<h2 class="h2 py-8">新着情報一覧</h2>
+<div class="content-style">
+  <%= render partial: "layouts/content_card", collection: @new_contents, as: "content" %>
+</div>
 
 <!-- ページネーション -->
 <%= paginate @new_contents, window: 1 %>

--- a/app/views/contents/popular.html.erb
+++ b/app/views/contents/popular.html.erb
@@ -1,5 +1,5 @@
-<h2 class="h2">人気情報一覧</h2>
-<div class="md:flex justify-center flex-wrap">
+<h2 class="h2 py-8">人気情報一覧</h2>
+<div class="content-style">
     <%= render partial: "layouts/content_card", collection: @popular_contents, as: "content" %>
 </div>
 

--- a/app/views/contents/recommend.html.erb
+++ b/app/views/contents/recommend.html.erb
@@ -1,6 +1,7 @@
-<h1>おすすめ情報一覧</h1>
-<div class="md:flex justify-center">
+<h2 class="h2 py-8">おすすめ情報一覧</h2>
+<div class="content-style">
   <%= render partial: "layouts/content_card", collection: @recommend_contents, as: "content" %>
 </div>
+
 <!-- ページネーション -->
-<%#= paginate @recommend_contents %>
+<%#= paginate @contents, window: 1 %>

--- a/app/views/contents/search.html.erb
+++ b/app/views/contents/search.html.erb
@@ -1,17 +1,20 @@
-<h2 class="h2">コンテンツ一覧</h2>
+<h2 class="h2 py-8">コンテンツ一覧</h2>
 
 <!-- content_search_word -->
 <% if params[:q].present? && @search_word.present? %>
-  <p>●「 <%= @search_word %> 」の検索結果<p>
+  <p>「 <%= @search_word %> 」の検索結果<p>
 <% end %>
 
 <% if params[:tag_id].present? && @search_word.present? %>
-  <p>●キーワード「 <%= @search_word %> 」<p>
+  <div>
+    <div class="text-dekiru-font text-sm">キーワード</div>
+    <div class="text-dekiru-font">「 <%= @search_word %> 」</div>
+  <div>
 <% end %>
 
 <!-- content_card -->
 <% if @contents.exists? %>
-  <div>
+  <div class="content-style">
     <%= render partial: "layouts/content_card", collection: @contents, as: "content" %>
   </div>
 <% else %>

--- a/app/views/contents/show.html.erb
+++ b/app/views/contents/show.html.erb
@@ -20,7 +20,7 @@
 <p>コメント:<%= @content.comment %></p>
 
 <!-- タグ -->
-<h2 class="h2">タグ</h2>
+<h2 class="h2 py-8">タグ</h2>
 <div>
   <% @content.tag_masters.each do |tag| %>
     <span class="content-tag-btn">
@@ -56,7 +56,7 @@
 
 <!-- 材料 -->
 <div class="mb-4">
-  <h2 class="h2">材料</h2>
+  <h2 class="h2 py-8">材料</h2>
   <% if admin_user? %>
     <%= link_to ">>追加", new_material_path(params: { content_id: @content.id }), class:"admin-link"%>
   <% end %>
@@ -67,7 +67,7 @@
 
 <!-- 作り方 -->
 <div class="mb-4">
-  <h2 class="h2">作り方</h2>
+  <h2 class="h2 py-8">作り方</h2>
   <% if admin_user? %>
     <%= link_to ">>追加", new_make_path(params: { content_id: @content.id }), class:"admin-link" %>
   <% end %>
@@ -76,7 +76,7 @@
 </div>  
 
 <!-- ポイント -->
-<h2 class="h2">ポイント</h2>
+<h2 class="h2 py-8">ポイント</h2>
 <p>コメント:<%= @content.point %></p>
 
 <br/>
@@ -84,7 +84,7 @@
 
 <!-- review -->
 <div class="mb-4">
-  <h2 class="h2">レビュー</h2>
+  <h2 class="h2 py-8">レビュー</h2>
   <% if general_user? %>
     <%= link_to ">>レビューする", new_review_path(params: { content_id: @content.id }), class:"blue-link" %>
   <% end %>
@@ -97,7 +97,7 @@
 
 
 <!-- 質問 -->
-<h2 class="h2">質問する</h2>
+<h2 class="h2 py-8">質問する</h2>
 
 <!-- 質問フォーム -->
 <% if user_signed_in? %>
@@ -112,7 +112,7 @@
 <br/>
 
 <!-- 質問と返信 -->
-<h2 class="h2">質問</h2>
+<h2 class="h2 py-8">質問</h2>
 <%= render partial: "question_card", collection: @questions, as: "question" %>
 
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,7 +10,7 @@
   <body>
     <%= render "layouts/flash" %>
     <%= render "layouts/header" %>
-    <div class="text-center mx-4 md:mx-20 xl:mx-80">  
+    <div class="text-center mx-4 md:mx-20 xl:mx-80">
       <%= yield %>
     </div>
     <%= render "layouts/footer"%>

--- a/app/views/responses/_form.html.erb
+++ b/app/views/responses/_form.html.erb
@@ -18,7 +18,7 @@
 
 <!-- 質問内容 -->
 <div class="bg-dekiru-light_blue">
-  <h2 class="h2">質問内容</h2>
+  <h2 class="h2 py-8">質問内容</h2>
   <div>
     <%= Question.find_by(@question).question_content %>
   </div>

--- a/app/views/users/confirmations/new.html.erb
+++ b/app/views/users/confirmations/new.html.erb
@@ -1,4 +1,4 @@
-<h2 class="h2">Resend confirmation instructions</h2>
+<h2 class="h2 py-8">Resend confirmation instructions</h2>
 
 <%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f| %>
   <%= render "users/shared/error_messages", resource: resource %>

--- a/app/views/users/favorite.html.erb
+++ b/app/views/users/favorite.html.erb
@@ -1,7 +1,7 @@
-<h2 class="h2">お気に入り一覧</h2>
+<h2 class="h2 py-8">お気に入り一覧</h2>
 
 <% if  @favorite_contents.exists? %>
-  <div class="md:flex justify-start flex-wrap">
+  <div class="content-style">
     <%= render partial: "layouts/content_card", collection: @favorite_contents, as: "content" %>
   </div>
 <% else %>

--- a/app/views/users/passwords/edit.html.erb
+++ b/app/views/users/passwords/edit.html.erb
@@ -1,4 +1,4 @@
-<h2 class="h2">Change your password</h2>
+<h2 class="h2 py-8">Change your password</h2>
 
 <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
   <%= render "users/shared/error_messages", resource: resource %>

--- a/app/views/users/passwords/new.html.erb
+++ b/app/views/users/passwords/new.html.erb
@@ -1,4 +1,4 @@
-<h2 class="h2">パスワード再設定</h2>
+<h2 class="h2 py-8">パスワード再設定</h2>
 
 <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
   <%= render "users/shared/error_messages", resource: resource %>

--- a/app/views/users/registrations/edit.html.erb
+++ b/app/views/users/registrations/edit.html.erb
@@ -1,6 +1,6 @@
 <%# TODO: ルーディングを調整すること%>
 
-<h2 class="h2">アカウント編集</h2>
+<h2 class="h2 py-8">アカウント編集</h2>
 <%= link_to "戻る", :back %>
 
 <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -1,4 +1,4 @@
-<h2 class="h2">アカウント新規作成</h2>
+<h2 class="h2 py-8">アカウント新規作成</h2>
 
 <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
   <div class="form-body">

--- a/app/views/users/shared/_error_messages.html.erb
+++ b/app/views/users/shared/_error_messages.html.erb
@@ -1,6 +1,6 @@
 <% if resource.errors.any? %>
   <div id="error_explanation">
-    <h2 class="h2">
+    <h2 class="h2 py-8">
       <%= I18n.t("errors.messages.not_saved",
                  count: resource.errors.count,
                  resource: resource.class.model_name.human.downcase)

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,63 +1,67 @@
-<h2 class="text-lg text-center">MyPage</h2>
+<div class="text-center pt-16 pb-32">
+  <!-- タイトル-->
+  <h2 class="h2 py-8">MyPage</h2>
 
-<div class="text-center">
-  <!-- 写真-->
-  <div class="image-style">
-    <%= image_tag @user.thumbnail.url%>
+  <!-- 写真 + 名前 -->
+  <div>
+    <!-- 写真-->
+    <div class="image-style">
+      <%= image_tag @user.thumbnail.url%>
+    </div>
+    <!-- 名前-->
+    <p>ユーザー名：<%= @user.name %></p>
   </div>
-  <!-- 名前-->
-  <h1>名前：<%= @user.name %></h1>
-<div>
 
-<!-- お気に入り一覧-->
-<div class="my-8 text-center">
-  <%= link_to favorite_contents_path, class:"blue-link border border-blue-500 w-40 py-2 px-4 hover:bg-dekiru-blue hover:text-white" do %>
-    <button class="w-32">お気に入り一覧</button>
-  <% end %>
-</div>
-
-<!-- アカウント編集-->
-<div class="my-8 text-center">
-  <%= link_to edit_user_registration_path(current_user), class:"blue-link border border-blue-500  py-2 px-4 hover:bg-dekiru-blue hover:text-white" do %>
-    <button class="w-32">アカウント編集</button>
-  <% end %>
-</div>
-
-<!-- ログアウト-->
-<div class="my-8 text-center">
-  <%= link_to destroy_user_session_path, method: :delete, data: { confirm: "ログアウトしますか？" }, class: "red-link w-40 border border-red-500 py-2 px-4 w-32 hover:bg-red-500 hover:text-white" do%>
-    <button class="w-32">ログアウト</button>
-  <% end %>
-</div>
-
-<hr>
-
-<% if admin_user? %>
-  <div class="text-left">
-    <h2 class="m-4">管理者専用</p>
-    
-    <br/>
-
-    <h2 class="m-4">1.タグ一覧</p>
-    <%= link_to ">>追加", new_tag_master_path, class:"admin-link" %>
-    <%= render partial: "layouts/content_tag", collection: @content_tags, as: "tag" %>
+  <!-- お気に入り一覧-->
+  <div class="my-8 text-center">
+    <%= link_to favorite_contents_path, class:"blue-link border border-blue-500 w-40 py-2 px-4 hover:bg-dekiru-blue hover:text-white" do %>
+      <button class="w-32">お気に入り一覧</button>
+    <% end %>
+  </div>
   
-    <br/>
-
-    <h2 class="m-4">2.カテゴリー作成</p>
-    <div>
-      <%= link_to ">>追加", new_category_path, class:"admin-link" %>
-    </div>
+  <!-- アカウント編集-->
+  <div class="my-8 text-center">
+    <%= link_to edit_user_registration_path(current_user), class:"blue-link border border-blue-500  py-2 px-4 hover:bg-dekiru-blue hover:text-white" do %>
+      <button class="w-32">アカウント編集</button>
+    <% end %>
+  </div>
   
-    <br/>
+  <!-- ログアウト-->
+  <div class="my-8 text-center">
+    <%= link_to destroy_user_session_path, method: :delete, data: { confirm: "ログアウトしますか？" }, class: "red-link w-40 border border-red-500 py-2 px-4 w-32 hover:bg-red-500 hover:text-white" do%>
+      <button class="w-32">ログアウト</button>
+    <% end %>
+  </div>
 
-    <div>
-      <h2 class="h2">3.コンテンツ作成</p>
-      <!-- 新規作成リンク(管理者のみ) -->
-      <div><%= link_to ">>新規作成",new_content_path, class:"admin-link" %></div>
-    </div>
-    
-    
-    </div>  
 
-<% end %>
+
+  
+  <!-- 管理者専用-->
+  <% if admin_user? %>
+    <div class="text-left p-8">
+      <h2 class="text-pink-500">管理者専用</h2>
+      
+  
+      <h2 class="h2 py-8">1.タグ一覧</h2>
+      <%= link_to ">>追加", new_tag_master_path, class:"admin-link" %>
+      <%= render partial: "layouts/content_tag", collection: @content_tags, as: "tag" %>
+    
+  
+      <h2 class="h2 py-8">2.カテゴリー作成</h2>
+      <div>
+        <%= link_to ">>追加", new_category_path, class:"admin-link" %>
+      </div>
+    
+  
+      <div>
+        <h2 class="h2 py-8">3.コンテンツ作成</h2>
+        <!-- 新規作成リンク(管理者のみ) -->
+        <div><%= link_to ">>新規作成",new_content_path, class:"admin-link" %></div>
+      </div>
+      
+      
+  
+    <% end %>
+  
+  
+  </div>  

--- a/app/views/users/unlocks/new.html.erb
+++ b/app/views/users/unlocks/new.html.erb
@@ -1,4 +1,4 @@
-<h2 class="h2">Resend unlock instructions</h2>
+<h2 class="h2 py-8">Resend unlock instructions</h2>
 
 <%= form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f| %>
   <%= render "users/shared/error_messages", resource: resource %>


### PR DESCRIPTION
## 実装の目的と概要
- コンテンツの表示を修正

## 実装内容(技術的な点を記載)
- [x] コンテンツの表示を修正
- [x] コンテンツ用のクラスを作成して、差分を統一
- [x] user/showの修正
- [x] カテゴリー詳細画面の実装

## スクリーンショット（画面レイアウトを変更した場合）
<img width="1680" alt="スクリーンショット 2021-06-06 14 18 31" src="https://user-images.githubusercontent.com/64491435/120913436-2b7d5d00-c6d2-11eb-8387-3fc4d77d6997.png">
<img width="1680" alt="スクリーンショット 2021-06-06 14 18 37" src="https://user-images.githubusercontent.com/64491435/120913438-30daa780-c6d2-11eb-9029-3777886394a4.png">


## チェックリスト

- [x] ローカル環境での動作確認をしたか（影響し得る範囲も含めて）
- [x] rubocopを実行して警告が出力されていないか
- [x] GitHub で ファイル差分（Files changed）を確認し、内容が合っているか。不要なファイルに差分がでていないか
- [x] テストでエラーが発生していないか
