### PR TITLE
[レイアウト]お問い合わせフォームのレイアウトを実装

### DIFF
--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -74,7 +74,6 @@
   @apply text-pink-500  text-sm
 }
 
-
 //************カード**************//
 .image-style {
   @apply w-60 m-auto p-4
@@ -86,23 +85,21 @@
 }
 
 .form-title {
-  @apply text-lg block mt-4 mb-2 text-left text-gray-500 border-l-4 pl-2 border-dekiru-font
+  @apply text-lg block mt-8 mb-4 text-left text-gray-500 border-l-4 pl-2 border-dekiru-blue
 }
 
 .text-field {
-  @apply border w-full py-2 focus:outline-none focus:border-gray-500 focus:bg-gray-100
+  @apply border text-dekiru-font w-full py-2 focus:outline-none focus:border-dekiru-blue focus:bg-dekiru-light_blue focus:opacity-30
 }
-//TODO: border-b-2を入れるとエラーが出るので対応する
 
+.text-area {
+  @apply border text-dekiru-font　w-full py-8 focus:outline-none focus:border-dekiru-blue focus:bg-dekiru-light_blue focus:opacity-30
+}
+
+//TODO: border-b-2を入れるとエラーが出るので対応する
 .login-field {
   @apply border-b w-full py-2 focus:outline-none focus:border-gray-500 focus:bg-gray-100
 }
-
-
-.text-area {
-  @apply border w-full py-8 focus:outline-none focus:border-gray-500 focus:bg-gray-100 
-}
-
 
 //************ コンテンツ  **************//
 .content-style {

--- a/app/views/contacts/_confirm_fields.html.erb
+++ b/app/views/contacts/_confirm_fields.html.erb
@@ -7,7 +7,7 @@
   </div>
   <div>
     <span><%= form.label :content, class:"form-title" %></span>
-    <%= form.text_area :content, readonly: true %>
+    <%= form.text_area :content, readonly: true, class:"text-area" %>
     <%= form.hidden_field :content %>
   </div>
 </div>

--- a/app/views/contacts/_submit_fields.html.erb
+++ b/app/views/contacts/_submit_fields.html.erb
@@ -1,8 +1,8 @@
   <div>
-    <span><%= form.label :title, class:"form-title" %> (必須)</span>
+    <span><%= form.label :title, class:"form-title" %></span>
     <%= form.text_field :title, required: true, class: "text-field" %>
   </div>
   <div>
-    <span><%= form.label :content, class:"form-title" %> (必須)</span>
+    <span><%= form.label :content, class:"form-title" %></span>
     <p><%= form.text_area :content, required: true, class:"text-area" %></p>
   </div>

--- a/app/views/contacts/index.html.erb
+++ b/app/views/contacts/index.html.erb
@@ -1,30 +1,24 @@
-<div>
-    <div>
-      <div>
-        <h1>お問い合わせ<%= " 《確認》" if @contact.submitted == "1" %></h1>
-      </div>
-      <div>
-        <%= form_with model: @contact, local: true do |form| %>
-          <div class="form-body">
+<h2 class="h2 mt-16 mb-12">お問い合わせ<%= " 《確認》" if @contact.submitted == "1" %></h2>
+<div class="pb-8">
+  <%= form_with model: @contact, local: true do |form| %>
+    <div class="form-body">
 
-            <%= render 'layouts/error_messages', model: form.object %>
-            <%= form.hidden_field :submitted %>
+      <%= render 'layouts/error_messages', model: form.object %>
+      <%= form.hidden_field :submitted %>
 
-            <% if @contact.submitted == "1" %>   
-              <%# 確認画面 %>
-              <%= render "confirm_fields", form: form %>
-              <div>
-                <div><%= form.button "戻る", name: "contact[confirmed]", value: "" %></div>
-                <div><%= form.button "送信", name: "contact[confirmed]", value: "1" %></div>
-              </div>
-                <% else %>
-              <%# 投稿画面 %>
-              <%= render "submit_fields", form: form %>
-              <div><%= form.submit "確認" %></div>
-            <% end %>
-
-          </div>
-        <% end %>
+      <% if @contact.submitted == "1" %>
+        <%# 確認画面 %>
+        <%= render "confirm_fields", form: form %>
+        <div>
+          <div class="mt-4"><%= form.button "戻る", name: "contact[confirmed]", value: "", class:"submit-btn" %></div>
+          <div><%= form.button "送信", name: "contact[confirmed]", value: "1", class:"submit-btn" %></div>
         </div>
+          <% else %>
+        <%# 投稿画面 %>
+        <%= render "submit_fields", form: form %>
+        <div class="py-8"><%= form.submit "確認", class:"submit-btn" %></div>
+      <% end %>
+
     </div>
+  <% end %>
 </div>


### PR DESCRIPTION
## 実装の目的と概要
- お問い合わせフォームのレイアウトを実装

## 実装内容(技術的な点を記載)
- [x] お問い合わせフォームのレイアウトを実装

## スクリーンショット（画面レイアウトを変更した場合）
<img width="840" alt="スクリーンショット 2021-06-06 15 00 08" src="https://user-images.githubusercontent.com/64491435/120914299-510d6500-c6d8-11eb-88e2-bd31d491de68.png">
<img width="840" alt="スクリーンショット 2021-06-06 15 00 16" src="https://user-images.githubusercontent.com/64491435/120914303-54085580-c6d8-11eb-8fc5-3e0a7965f502.png">

## チェックリスト

- [x] ローカル環境での動作確認をしたか（影響し得る範囲も含めて）
- [x] rubocopを実行して警告が出力されていないか
- [x] GitHub で ファイル差分（Files changed）を確認し、内容が合っているか。不要なファイルに差分がでていないか
- [x] テストでエラーが発生していないか
