### PR TITLE
[機能開発]質問の削除を制限する

### DIFF
--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -19,8 +19,10 @@ class QuestionsController < ApplicationController
   end
 
   def destroy
-    @question.destroy!
-    redirect_to content_show_path(@question.content.id), alert: "質問を削除しました"
+    if @question.response_nil?  # 返信が存在している場合、削除できない
+      @question.destroy!
+      redirect_to content_show_path(@question.content.id), alert: "質問を削除しました"
+    end
   end
 
   private

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -5,6 +5,11 @@ class Question < ApplicationRecord
 
   validates :question_content, presence: true, length: { in: 1..100, allow_blank: true }
 
+  def response_nil?
+    self.response.nil?
+  end
+
+  # エラーメッセージ
   def self.question_error_message(q)
     case q.errors.full_messages
     when ["Question contentを入力してください"]

--- a/app/views/contents/_question_card.html.erb
+++ b/app/views/contents/_question_card.html.erb
@@ -14,10 +14,14 @@
     </div>
 
     <!-- 質問CRUD -->
+    <%# TODO: リファクタリングする %>
     <% if question.user == current_user || admin_user? %>
+      <% if question.response.nil? %>
       <div class="text-left p-4">
         <%= link_to ">>削除", question_path(question), data: { confirm: '確定します。よろしいでしょうか？'}, method: :delete, class:"red-link" %>
       </div>
+    <% end %>
+
     <% end %>
   </div>
 


### PR DESCRIPTION
## 実装の目的と概要
- 質問の削除を以下の条件下のみで許可する
  -  質問に対して返信がない場合

## 実装内容(技術的な点を記載)
- [x] 返信がある場合、質問の削除ボタンを非表示にする
- [x] 返信がある場合に質問を削除した場合、条件分岐で削除できない

## チェックリスト

- [x] ローカル環境での動作確認をしたか（影響し得る範囲も含めて）
- [x] rubocopを実行して警告が出力されていないか
- [x] GitHub で ファイル差分（Files changed）を確認し、内容が合っているか。不要なファイルに差分がでていないか
- [x] テストでエラーが発生していないか
