### PR TITLE
[レイアウト]movieの位置を実装

### DIFF
--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -126,3 +126,10 @@
 .required_content {
   @apply text-sm ml-2 bg-red-400 text-white p-1
 }
+
+iframe {
+  width: 100%;
+  max-width: 556px;
+  height: 315px;
+  margin: 0 auto;
+}

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -17,13 +17,13 @@
 //mailボタン
 // TODO: hover用の色を作成すること
 .blue-btn {
-  @apply bg-dekiru-blue hover:bg-dekiru-light_blue text-white font-bold py-2 px-4  rounded-lg
+  @apply bg-dekiru-blue hover:bg-dekiru-light_blue text-white font-bold py-2 px-4 rounded-lg
 }
 
 //deleteボタン
 // TODO: 色を検討する
 .red-btn {
-  @apply bg-red-500 hover:bg-red-700 text-white font-bold py-2 px-4  rounded-lg
+  @apply bg-red-500 hover:bg-red-700 text-white font-bold py-2 px-4 rounded-lg
 }
 
 //詳細遷移ボタン
@@ -39,17 +39,17 @@
 }
 
 .no-favorite-btn {
-  @apply text-green-500 border border-green-500 hover:bg-green-700  font-bold py-2 px-4 rounded-full
+  @apply text-green-500 border border-green-500 hover:bg-green-700 font-bold py-2 px-4 rounded-full
 }
 
 //カテゴリータグ
 .category-tag-btn {
-  @apply text-white bg-dekiru-blue border-0  m-1 py-2 px-6 focus:outline-none text-lg
+  @apply text-white bg-dekiru-blue border-0 m-1 py-2 px-6 focus:outline-none text-lg
 }
 
 //コンテンツタグ
 .content-tag-btn {
-  @apply text-white bg-dekiru-keyword border-0  m-1 py-2 px-6 focus:outline-none text-lg
+  @apply text-white bg-dekiru-keyword border-0 m-1 py-2 px-6 focus:outline-none text-lg
 }
 
 //TOOD: 色を検討する,hoverも同様
@@ -71,7 +71,7 @@
 
 //管理者CRUDリンク
 .admin-link {
-  @apply text-pink-500  text-sm
+  @apply text-pink-500 text-sm
 }
 
 //************カード**************//
@@ -101,14 +101,14 @@
   @apply border-b w-full py-2 focus:outline-none focus:border-gray-500 focus:bg-gray-100
 }
 
-//************ コンテンツ  **************//
+//************ コンテンツ **************//
 .content-style {
   @apply md:flex justify-center flex-wrap mb-16
 }
 
-//************ ページネーション  **************//
+//************ ページネーション **************//
 .page-link {
-  @apply text-dekiru-blue py-4 px-4  my-4 border hover:bg-dekiru-blue hover:text-white
+  @apply text-dekiru-blue py-4 px-4 my-4 border hover:bg-dekiru-blue hover:text-white
 }
 
 //activeの場合、固定する
@@ -121,15 +121,22 @@
   @apply text-dekiru-blue py-4 px-24 mx-1 my-4 border hover:bg-dekiru-blue hover:text-white
 }
 
-//************ その他  **************//
+//************ その他 **************//
 //必須マーク
 .required_content {
   @apply text-sm ml-2 bg-red-400 text-white p-1
 }
 
+//************ movie **************//
+.movie__inner {
+  position: relative;
+  padding-bottom: calc(315 / 560 * 100%);
+}
+
 iframe {
+  position: absolute;
+  top: 0;
+  right: 0;
   width: 100%;
-  max-width: 556px;
-  height: 315px;
-  margin: 0 auto;
+  height: 100%;
 }

--- a/app/views/contents/show.html.erb
+++ b/app/views/contents/show.html.erb
@@ -14,15 +14,14 @@
 
 <!-- コンテンツ -->
 <div class="mb-8 border bg-gray-100">
+
   <!-- movie -->
-  <div class="p-4 mb-4 m-auto">
-    <div class="w-full">
-      <%= embed_youtube(@content.movie_url) %>
-    </div>
+  <div class="px-2 pt-16 pb-4">
+    <%= embed_youtube(@content.movie_url) %>
   </div>
 
   <!-- お気に入り -->
-  <div class=" pb-4">
+  <div class="pb-4">
     <%#= render partial: "favorite_card", collection: @makes, as: "make" %>
     <div class="mb-4" if="content-<%= @content.id %>">
       <%# TODO: 条件分岐をリファクタリングすること%>

--- a/app/views/contents/show.html.erb
+++ b/app/views/contents/show.html.erb
@@ -16,8 +16,10 @@
 <div class="mb-8 border bg-gray-100">
 
   <!-- movie -->
-  <div class="px-2 pt-16 pb-4">
-    <%= embed_youtube(@content.movie_url) %>
+  <div class="movie">
+    <div class="movie__inner">
+      <%= embed_youtube(@content.movie_url) %>
+    </div>
   </div>
 
   <!-- お気に入り -->


### PR DESCRIPTION
## 実装の目的と概要
- movieの位置を実装
## 実装内容(技術的な点を記載)
- movieの位置を中央に実装

## スクリーンショット（画面レイアウトを変更した場合）
<img width="836" alt="スクリーンショット 2021-06-07 17 27 11" src="https://user-images.githubusercontent.com/64491435/120985049-30b3d800-c7b6-11eb-9f1f-bad05e9c6b74.png">

## 参考資料
- [【初学者向け】レスポンシブ対応でYouTube動画を埋め込む](https://www.wetch.co.jp/%E3%80%90%E5%88%9D%E5%AD%A6%E8%80%85%E5%90%91%E3%81%91%E3%80%91%E3%83%AC%E3%82%B9%E3%83%9D%E3%83%B3%E3%82%B7%E3%83%96%E5%AF%BE%E5%BF%9C%E3%81%A7youtube%E5%8B%95%E7%94%BB%E3%82%92%E5%9F%8B%E3%82%81/)
## チェックリスト

- [x] ローカル環境での動作確認をしたか（影響し得る範囲も含めて）
- [x] rubocopを実行して警告が出力されていないか
- [x] GitHub で ファイル差分（Files changed）を確認し、内容が合っているか。不要なファイルに差分がでていないか
- [x] テストでエラーが発生していないか

## 備考（実装していないことなど）
