### PR TITLE
[レイアウト]サムネイル画像にringを実装

### DIFF
--- a/app/views/contents/_question_card.html.erb
+++ b/app/views/contents/_question_card.html.erb
@@ -4,8 +4,8 @@
   <div  class="border border-gray-300 rounded-lg mb-4">
     <!-- 質問ユーザー -->
     <div class="flex px-4 py-8">
-      <%= image_tag question.user.thumbnail.thumb27.url %>
-      <%= question.user.name %>
+      <%= image_tag question.user.thumbnail.thumb27.url, class:"rounded-full border border-gray-300"%>
+      <span class="ml-4"><%= question.user.name %></span>
     </div>
 
     <!-- 質問内容 -->
@@ -32,8 +32,8 @@
     <% if question.response.present?%> <%# 返信がある場合、返信を表示する%>
       <!-- DEKRIU情報 -->
       <div class="flex justify-end px-4 py-8">
-        <span>deKiRU</span><!-- TODO: 少し変かもしれない。全て大文字にするか相談する -->
-        <%= image_tag @admin.thumbnail.thumb27.url %>
+        <span class="mr-4">deKiRU</span><!-- TODO: 少し変かもしれない。全て大文字にするか相談する -->
+        <%= image_tag @admin.thumbnail.thumb27.url ,class:"rounded-full border border-gray-300"%>
       </div>
       <!-- 返信内容 -->
       <div class="text-right px-4 py-8">

--- a/app/views/contents/_review_card.html.erb
+++ b/app/views/contents/_review_card.html.erb
@@ -6,7 +6,7 @@
 
   <!-- ユーザー情報 -->
   <div class="flex justify-start p-4">
-    <%=image_tag review.user.thumbnail.thumb27.url %>
+    <%=image_tag review.user.thumbnail.thumb27.url,class:"rounded-full border-2 border-gray-300" %>
     <span class="ml-4"><%= review.user.name %><span>
   </div>
 

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -3,13 +3,13 @@
   <h2 class="h2 py-8">MyPage</h2>
 
   <!-- 写真 + 名前 -->
-  <div>
+  <div class="py-8">
     <!-- 写真-->
-    <div class="image-style">
-      <%= image_tag @user.thumbnail.url%>
+      <div class="image-style m-auto">
+      <%= image_tag @user.thumbnail.url ,class:"w-full rounded-full border-4 border-dekiru-blue"%>
     </div>
     <!-- 名前-->
-    <p>ユーザー名：<%= @user.name %></p>
+    <p class="text-lg"><%= @user.name %></p>
   </div>
 
   <!-- お気に入り一覧-->


### PR DESCRIPTION
## 実装の目的と概要
- サムネイル画像にringを実装
## 実装内容(技術的な点を記載)
- サムネイル画像にringを実装
 

## スクリーンショット（画面レイアウトを変更した場合）
<img width="836" alt="スクリーンショット 2021-06-07 21 18 57" src="https://user-images.githubusercontent.com/64491435/121017219-007d3100-c7d8-11eb-9879-bae918fbfe30.png">
<img width="836" alt="スクリーンショット 2021-06-07 21 19 10" src="https://user-images.githubusercontent.com/64491435/121017236-0410b800-c7d8-11eb-92a3-5e0ce1e246a5.png">
<img width="836" alt="スクリーンショット 2021-06-07 21 19 07" src="https://user-images.githubusercontent.com/64491435/121017240-04a94e80-c7d8-11eb-9a12-45dae24b3f30.png">



## チェックリスト

- [x] ローカル環境での動作確認をしたか（影響し得る範囲も含めて）
- [x] rubocopを実行して警告が出力されていないか
- [x] GitHub で ファイル差分（Files changed）を確認し、内容が合っているか。不要なファイルに差分がでていないか
- [x] テストでエラーが発生していないか
