### PR TITLE
[テスト]専用リンクのフィーチャーテストを実装

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -32,17 +32,18 @@ class User < ApplicationRecord
     end
   end
 
+  # TODO: ゲストユーザにテストデータを作成する場合
   def self.create_guest_sample_date
-    gest_user = User.find_by(email: "guest@example.com")
-    favorite_num = 10
+    # gest_user = User.find_by(email: "guest@example.com")
 
     # お気に入りサンプルデータ
-    favorite_num.times do
-      content = Content.all.sample
-      gest_user.favorites.find_or_create_by!(content_id: content.id) do |f|
-        f.content_id = content.id
-      end
-    end
+    # favorite_num = 10
+    # favorite_num.times do
+    #   content = Content.all.sample
+    #   gest_user.favorites.find_or_create_by!(content_id: content.id) do |f|
+    #     f.content_id = content.id
+    #   end
+    # end
 
     # TODO: 画像導入時にエラーが発生
     # reviews_num = 3

--- a/app/views/contents/show.html.erb
+++ b/app/views/contents/show.html.erb
@@ -26,20 +26,18 @@
   <div class="pb-4">
     <%#= render partial: "favorite_card", collection: @makes, as: "make" %>
     <div class="mb-4" if="content-<%= @content.id %>">
+      <% if general_user? %>
       <%# TODO: 条件分岐をリファクタリングすること%>
-      <% if user_signed_in? %>
         <div class="my-4">
           <% if @content.favorited_by?(current_user) %>
-            <%# お気に入りから外す %>
-            <%= link_to "お気に入り", content_favorites_path(@content), method: :delete, remote: true, class:"favorite-btn" %>
+            <%= link_to "お気に入り", content_favorites_path(@content), method: :delete, remote: true, class:"favorite-btn" %> <%# お気に入りから外す %>
           <% else %>
-            <%# お気に入りに追加 %>
-            <%= link_to "お気に入りする", content_favorites_path(@content), method: :post, remote: true, class:"no-favorite-btn" %>
+            <%= link_to "お気に入りする", content_favorites_path(@content), method: :post, remote: true, class:"no-favorite-btn" %><%# お気に入りに追加 %>
           <% end %>
         </div>
       <% end %>
     </div>
-    <!-- <p>お気に入り数:<%= @content.favorites.count %></p> -->
+    <p>お気に入り数:<%= @content.favorites.count %></p>
   </div>
 
   <!-- 説明 -->

--- a/app/views/layouts/_flash.html.erb
+++ b/app/views/layouts/_flash.html.erb
@@ -12,7 +12,7 @@
         </div>
       </div>
     </div>
-  <% else %>
+  <% elsif flash_type == "alert" %>
     <!-- 赤色の通知-->
     <div class="flex flex-col space-y-3 p-3">
       <div class="bg-red-100 p-5 w-full border-l-4 border-red-700">

--- a/spec/features/contents_spec.rb
+++ b/spec/features/contents_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "Contents", type: :feature do
       it "ユーザー専用リンクが表示されないこと" do
         visit content_show_path(@content.id)
         expect(page).not_to have_link ">>レビューする", href: new_review_path(params: { content_id: @content.id })
-        # お気に入りリンクが表示されない
+        expect(page).not_to have_link "お気に入りする", href: content_favorites_path(@content)
       end
 
       it "管理者専用リンクが表示されないこと" do
@@ -42,7 +42,7 @@ RSpec.describe "Contents", type: :feature do
         sign_in @user
         visit content_show_path(@content.id)
         expect(page).to have_link ">>レビューする", href: new_review_path(params: { content_id: @content.id })
-        # お気に入りリンクが表示される
+        expect(page).to have_link "お気に入りする", href: content_favorites_path(@content)
       end
 
       it "管理者専用リンクが表示されないこと" do
@@ -81,8 +81,8 @@ RSpec.describe "Contents", type: :feature do
     # 管理者
   context "管理者の場合" do
     it "ユーザー専用リンクが表示されないこと" do
-        # お気に入りボタン
       expect(page).not_to have_link ">>レビューする", href: new_review_path(params: { content_id: @content.id })
+      expect(page).not_to have_link "お気に入りする", href: content_favorites_path(@content)
     end
 
     it "管理者専用リンクが表示されること" do

--- a/spec/features/contents_spec.rb
+++ b/spec/features/contents_spec.rb
@@ -13,8 +13,6 @@ RSpec.describe "Contents", type: :feature do
   end
 
   describe "GET #show" do
-    let(:content) { create(:content) }
-
     context "未ログインユーザーの場合" do
       # 異常値のみ
       it "各リンクが表示されないこと" do

--- a/spec/features/contents_spec.rb
+++ b/spec/features/contents_spec.rb
@@ -13,9 +13,15 @@ RSpec.describe "Contents", type: :feature do
   end
 
   describe "GET #show" do
+    # 未ログインユーザー
     context "未ログインユーザーの場合" do
-      # 異常値のみ
-      it "各リンクが表示されないこと" do
+      it "ユーザー専用リンクが表示されないこと" do
+        visit content_show_path(@content.id)
+        expect(page).not_to have_link ">>レビューする", href: new_review_path(params: { content_id: @content.id })
+        # お気に入りリンクが表示されない
+      end
+
+      it "管理者専用リンクが表示されないこと" do
         visit content_show_path(@content.id)
         expect(page).not_to have_link ">>追加", href: new_material_path(params: { content_id: @content.id }) # 材料新規作成
         expect(page).not_to have_link ">>追加", href: new_make_path(params: { content_id: @content.id }) # 作り方新規作成
@@ -23,18 +29,23 @@ RSpec.describe "Contents", type: :feature do
         expect(page).not_to have_link ">>削除", href: material_path(@material.id)
         expect(page).not_to have_link ">>編集", href: edit_make_path(@make.id, params: { content_id: @make.content.id })
         expect(page).not_to have_link ">>削除", href: make_path(@make.id)
-        expect(page).not_to have_link ">>レビューする", href: new_review_path(params: { content_id: @content.id })
-        expect(page).not_to have_link ">>削除", href: question_path(@do_question)
         expect(page).not_to have_link ">>削除", href: question_path(@end_question)
-        expect(page).not_to have_link "返信する", href: new_response_path(question_id: @do_question.id)
+        expect(page).not_to have_link ">>返信する", href: new_response_path(question_id: @do_question.id)
         expect(page).not_to have_link ">>編集", href: edit_response_path(@end_question.response, question_id: @end_question.id)
         expect(page).not_to have_link ">>削除", href: response_path(@end_question.response)
       end
     end
 
+    # ログインユーザー
     context "ユーザーが一般ユーザーの場合" do
-      # 異常値のみ
-      it "各リンクが表示されないこと" do
+      it "ユーザー専用リンクが表示されること" do
+        sign_in @user
+        visit content_show_path(@content.id)
+        expect(page).to have_link ">>レビューする", href: new_review_path(params: { content_id: @content.id })
+        # お気に入りリンクが表示される
+      end
+
+      it "管理者専用リンクが表示されないこと" do
         sign_in @user
         visit content_show_path(@content.id)
         expect(page).not_to have_link ">>追加", href: new_material_path(params: { content_id: @content.id }) # 材料新規作成
@@ -43,8 +54,6 @@ RSpec.describe "Contents", type: :feature do
         expect(page).not_to have_link ">>削除", href: material_path(@material.id)
         expect(page).not_to have_link ">>編集", href: edit_make_path(@make.id, params: { content_id: @make.content.id })
         expect(page).not_to have_link ">>削除", href: make_path(@make.id)
-        expect(page).to have_link ">>レビューする", href: new_review_path(params: { content_id: @content.id })
-        expect(page).to have_link ">>削除", href: question_path(@do_question)
         expect(page).not_to have_link ">>削除", href: question_path(@end_question)
         expect(page).not_to have_link ">>返信する", href: new_response_path(question_id: @do_question.id)
         expect(page).not_to have_link ">>編集", href: edit_response_path(@end_question.response, question_id: @end_question.id)
@@ -52,24 +61,50 @@ RSpec.describe "Contents", type: :feature do
       end
     end
 
-    context "管理者の場合" do
-      it "新規作成リンクが表示されること" do
+    context "自分の質問に返信がない場合" do
+      it "質問削除リンクが表示されること" do
+        sign_in @user
+        visit content_show_path(@content.id)
+        expect(page).to have_link ">>削除", href: question_path(@do_question)
+      end
+    end
+
+    context "自分の質問に返信がある場合" do
+      it "質問削除リンクが表示されないこと" do
+        sign_in @user
+        visit content_show_path(@content.id)
+        expect(page).not_to have_link ">>削除", href: question_path(@end_question)
+      end
+    end
+  end
+
+    # 管理者
+  context "管理者の場合" do
+    it "ユーザー専用リンクが表示されないこと" do
+        # お気に入りボタン
+      expect(page).not_to have_link ">>レビューする", href: new_review_path(params: { content_id: @content.id })
+    end
+
+    it "管理者専用リンクが表示されること" do
+      sign_in @admin
+      visit content_show_path(@content.id)
+      expect(page).to have_link ">>編集", href: edit_content_path(@content) # コンテンツ編集リンク
+      expect(page).to have_link ">>削除", href: content_path(@content) # コンテンツ削除リンク
+      expect(page).to have_link ">>追加", href: new_material_path(params: { content_id: @content.id }) # 材料追加
+      expect(page).to have_link ">>追加", href: new_make_path(params: { content_id: @content.id }) # 作り方追加
+    end
+
+    context "材料が存在する時" do
+      it "リンクが表示される" do
         sign_in @admin
         visit content_show_path(@content.id)
-        expect(page).to have_link ">>追加", href: new_material_path(params: { content_id: @content.id }) # 材料新規作成
-        expect(page).to have_link ">>追加", href: new_make_path(params: { content_id: @content.id }) # 作り方新規作成
+        expect(page).to have_link ">>編集", href: edit_material_path(@material.id, params: { content_id: @material.content.id })
+        expect(page).to have_link ">>削除", href: material_path(@material.id)
       end
+    end
 
-      context "材料が存在する時" do
-        it "リンクが表示される" do
-          sign_in @admin
-          visit content_show_path(@content.id)
-          expect(page).to have_link ">>編集", href: edit_material_path(@material.id, params: { content_id: @material.content.id })
-          expect(page).to have_link ">>削除", href: material_path(@material.id)
-        end
-      end
-
-      it "作り方が存在する時、リンクが表示される" do
+    context "作り方が存在する時" do
+      it "リンクが表示される" do
         sign_in @admin
         visit content_show_path(@content.id)
         expect(page).to have_link ">>編集", href: edit_make_path(@make.id, params: { content_id: @make.content.id })
@@ -90,8 +125,8 @@ RSpec.describe "Contents", type: :feature do
         expect(page).not_to have_button "質問する"
       end
 
-      context "質問があるが,返信がない場合" do
-        it "リンクが表示される" do
+      context "質問があり,返信がない場合" do
+        it "質問削除・返信作成リンクが表示される" do
           sign_in @admin
           visit content_show_path(@content.id)
           expect(page).to have_link ">>削除", href: question_path(@do_question)
@@ -100,7 +135,7 @@ RSpec.describe "Contents", type: :feature do
       end
 
       context "質問があり,返信がある場合" do
-        it "リンクが表示される" do
+        it "返信編集・返信削除リンクが表示される" do
           sign_in @admin
           visit content_show_path(@content.id)
           expect(page).to have_link ">>編集", href: edit_response_path(@end_question.response, question_id: @end_question.id)

--- a/spec/features/homes_spec.rb
+++ b/spec/features/homes_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe "Homes", type: :feature do
     end
 
     context "管理者の場合" do
-      it "各リンクが表示されること", type: :do do
+      it "各リンクが表示されること" do
         sign_in @admin
         visit root_path
         expect(page).to have_link ">>編集", href: edit_tag_master_path(@tag.id) # タグ編集

--- a/spec/features/homes_spec.rb
+++ b/spec/features/homes_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Homes", type: :feature do
 
   describe "GET #index" do
     context "未ログインユーザーの場合" do
-      it "各リンクが表示されないこと" do
+      it "管理者専用リンクが表示されない" do
         visit root_path
         expect(page).not_to have_link ">>編集", href: edit_tag_master_path(@tag.id) # タグ編集
         expect(page).not_to have_link ">>削除", href: tag_master_path(@tag.id) # タグ削除
@@ -17,7 +17,7 @@ RSpec.describe "Homes", type: :feature do
     end
 
     context "ユーザーが一般ユーザーの場合" do
-      it "各リンクが表示されないこと" do
+      it "管理者専用リンクが表示されない" do
         sign_in @user
         visit root_path
         expect(page).not_to have_link ">>編集", href: edit_tag_master_path(@tag.id) # タグ編集
@@ -26,7 +26,7 @@ RSpec.describe "Homes", type: :feature do
     end
 
     context "管理者の場合" do
-      it "各リンクが表示されること" do
+      it "管理者専用リンクが表示される" do
         sign_in @admin
         visit root_path
         expect(page).to have_link ">>編集", href: edit_tag_master_path(@tag.id) # タグ編集

--- a/spec/features/homes_spec.rb
+++ b/spec/features/homes_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+RSpec.describe "Homes", type: :feature do
+  before do
+    @user = create(:user) # ユーザー
+    @admin = create(:user, user_type: "admin") # 管理者
+    @tag = create(:tag_master)
+  end
+
+  describe "GET #index" do
+    context "未ログインユーザーの場合" do
+      it "各リンクが表示されないこと" do
+        visit root_path
+        expect(page).not_to have_link ">>編集", href: edit_tag_master_path(@tag.id) # タグ編集
+        expect(page).not_to have_link ">>削除", href: tag_master_path(@tag.id) # タグ削除
+      end
+    end
+
+    context "ユーザーが一般ユーザーの場合" do
+      it "各リンクが表示されないこと" do
+        sign_in @user
+        visit root_path
+        expect(page).not_to have_link ">>編集", href: edit_tag_master_path(@tag.id) # タグ編集
+        expect(page).not_to have_link ">>削除", href: tag_master_path(@tag.id) # タグ削除
+      end
+    end
+
+    context "管理者の場合" do
+      it "各リンクが表示されること", type: :do do
+        sign_in @admin
+        visit root_path
+        expect(page).to have_link ">>編集", href: edit_tag_master_path(@tag.id) # タグ編集
+        expect(page).to have_link ">>削除", href: tag_master_path(@tag.id) # タグ削除
+      end
+    end
+  end
+end

--- a/spec/features/users_spec.rb
+++ b/spec/features/users_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+RSpec.describe "Users", type: :feature do
+  before do
+    @user = create(:user) # ユーザー
+    @admin = create(:user, user_type: "admin") # 管理者
+    @tag = create(:tag_master)
+  end
+
+  describe "GET #show" do
+    # MEMO: 未ログインユーザーの場合、遷移できないためテストなし
+
+    context "ユーザーが一般ユーザーの場合" do
+      it "管理者専用リンクが表示されないこと" do
+        sign_in @user
+        visit mypage_path(@user)
+        expect(page).not_to have_link ">>追加", href: new_tag_master_path # タグ追加
+        expect(page).not_to have_link ">>編集", href: edit_tag_master_path(@tag.id) # タグ編集
+        expect(page).not_to have_link ">>削除", href: tag_master_path(@tag.id) # タグ削除
+        expect(page).not_to have_link ">>追加", href: new_category_path # カテゴリー追加
+        expect(page).not_to have_link ">>新規作成", href: new_content_path # コンテンツ追加
+      end
+    end
+
+    context "管理者の場合" do
+      it "管理者専用リンクが表示されること" do
+        sign_in @admin
+        visit mypage_path(@admin)
+        expect(page).to have_link ">>追加", href: new_tag_master_path # タグ追加
+        expect(page).to have_link ">>編集", href: edit_tag_master_path(@tag.id) # タグ編集
+        expect(page).to have_link ">>削除", href: tag_master_path(@tag.id) # タグ削除
+        expect(page).to have_link ">>追加", href: new_category_path # カテゴリー追加
+        expect(page).to have_link ">>新規作成", href: new_content_path # コンテンツ追加
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 実装の目的と概要
- 専用リンクのフィーチャーテストを実装
## 実装内容(技術的な点を記載)
- [x] 管理者専用のリンクの表示をログインユーザによってテスト
- [x] お気に入りボタンを、ログインユーザーのみ表示できるよう実装
- [x] ゲストユーザーのログイン時のテストユーザー作成を一時コメントアウト

## チェックリスト

- [x] ローカル環境での動作確認をしたか（影響し得る範囲も含めて）
- [x] rubocopを実行して警告が出力されていないか
- [x] GitHub で ファイル差分（Files changed）を確認し、内容が合っているか。不要なファイルに差分がでていないか
- [x] テストでエラーが発生していないか

## 補足
- [ ] ゲストユーザーのログイン時のテストユーザー作成を一時コメントアウト
上記は別タスクにて、別でデータを持っている場合は、新たに作成しないように修正する