### PR TITLE
[フロント開発]フォームのレイアウトを実装

### DIFF
--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -80,20 +80,21 @@
 }
 
 //************ フォーム **************//
-.form-body {
-  @apply w-10/12 mx-auto md:max-w-md m-4
-}
+//消すかリファクタリングで使用するか
+// .form-body {
+//   @apply  
+// }
 
 .form-title {
   @apply text-lg block mt-8 mb-4 text-left text-gray-500 border-l-4 pl-2 border-dekiru-blue
 }
 
 .text-field {
-  @apply border text-dekiru-font w-full py-2 focus:outline-none focus:border-dekiru-blue focus:bg-dekiru-light_blue focus:opacity-30
+  @apply border text-dekiru-font w-full py-2 focus:outline-none focus:border-dekiru-blue max-w-4xl resize-none
 }
 
 .text-area {
-  @apply border text-dekiru-font　w-full py-8 focus:outline-none focus:border-dekiru-blue focus:bg-dekiru-light_blue focus:opacity-30 
+  @apply border text-dekiru-font　w-full py-8 focus:outline-none focus:border-dekiru-blue max-w-4xl resize-none
 }
 
 //TODO: border-b-2を入れるとエラーが出るので対応する

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -90,11 +90,11 @@
 }
 
 .text-field {
-  @apply border text-dekiru-font w-full py-2 focus:outline-none focus:border-dekiru-blue max-w-4xl resize-none
+  @apply border   text-dekiru-font w-full py-2 focus:outline-none focus:ring-1 focus:ring-dekiru-blue focus:ring-opacity-50 focus:border-dekiru-blue max-w-4xl resize-none rounded
 }
 
 .text-area {
-  @apply border text-dekiru-font w-full py-8 focus:outline-none focus:border-dekiru-blue max-w-4xl resize-none
+  @apply border text-dekiru-font w-full py-8 focus:outline-none focus:ring-1 focus:ring-dekiru-blue focus:ring-opacity-30 focus:border-dekiru-blue max-w-4xl resize-none rounded
 }
 
 //TODO: text-fieldは将来的にこちらを実装する予定

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -86,7 +86,7 @@
 // }
 
 .form-title {
-  @apply text-lg block mt-8 mb-4 text-left text-gray-500 border-l-4 pl-2 border-dekiru-blue
+  @apply text-lg block mt-8 mb-4 text-left text-gray-500 border-l-4 pl-2 border-dekiru-blue max-w-4xl mx-auto
 }
 
 .text-field {
@@ -94,12 +94,12 @@
 }
 
 .text-area {
-  @apply border text-dekiru-font　w-full py-8 focus:outline-none focus:border-dekiru-blue max-w-4xl resize-none
+  @apply border text-dekiru-font w-full py-8 focus:outline-none focus:border-dekiru-blue max-w-4xl resize-none
 }
 
-//TODO: border-b-2を入れるとエラーが出るので対応する
+//TODO: text-fieldは将来的にこちらを実装する予定
 .login-field {
-  @apply border-b w-full py-2 focus:outline-none focus:border-gray-500 focus:bg-gray-100
+  @apply border-b w-full py-2 focus:outline-none focus:border-gray-500 focus:bg-gray-100 max-w-4xl resize-none
 }
 
 //************ コンテンツ **************//
@@ -127,6 +127,12 @@
 .required_content {
   @apply text-sm ml-2 bg-red-400 text-white p-1
 }
+
+//補足コメント
+.supplement_comment {
+  @apply my-2 text-sm text-left block max-w-4xl mx-auto opacity-70
+}
+
 
 //************ movie **************//
 .movie__inner {

--- a/app/views/categories/_category_card.html.erb
+++ b/app/views/categories/_category_card.html.erb
@@ -9,7 +9,7 @@
         <i class="fas fa-pen"></i>
       <% end %>
       <!-- 削除ボタン-->
-      <%= link_to category_path(category), data: { confirm: '削除してもよろしいでしょうか？'}, method: :delete do %>
+      <%= link_to category_path(category), data: { confirm: '削除してもよろしいでしょうか？', disable_with: "送信中..."}, method: :delete do %>
        <i class="far fa-trash-alt"></i>
       <% end %>
     <% end %>

--- a/app/views/categories/_form.html.erb
+++ b/app/views/categories/_form.html.erb
@@ -2,7 +2,7 @@
   <div class="form-body">
     <%= render 'layouts/error_messages', model: f.object %>
     <h2 class="form-title">カテゴリー名<span class="required_content">必須</span></h2>
-    <%= f.text_field :name , class: "text-field", placeholder: "カテゴリー名(16文字以内)" %>
+    <%= f.text_field :name , placeholder: "カテゴリー名(16文字以内)", required: true, class: "text-field" %>
     <div>
       <%= f.submit "確定する", data: { confirm: '確定します。よろしいでしょうか？'}, class:"submit-btn" %>
     </div>

--- a/app/views/categories/_form.html.erb
+++ b/app/views/categories/_form.html.erb
@@ -4,7 +4,7 @@
     <h2 class="form-title">カテゴリー名<span class="required_content">必須</span></h2>
     <%= f.text_field :name , placeholder: "カテゴリー名(16文字以内)", required: true, class: "text-field" %>
     <div>
-      <%= f.submit "確定する", data: { confirm: '確定します。よろしいでしょうか？'}, class:"submit-btn" %>
+      <%= f.submit "確定する", data: { confirm: '確定します。よろしいでしょうか？', disable_with: "送信中..." }, class:"submit-btn" %>
     </div>
   </div>
 <% end %>

--- a/app/views/contacts/_submit_fields.html.erb
+++ b/app/views/contacts/_submit_fields.html.erb
@@ -1,6 +1,6 @@
   <div>
     <div class="form-title">お問い合わせタイトル<span class="required_content">必須</span></div>
-    <%= form.text_field :title, required: true, placeholder: "タイトル入力(32文字以内)", class: "text-field" %>
+    <%= form.text_field :title, placeholder: "タイトル入力(32文字以内)",required: true, class: "text-field" %>
   </div>
   <div>
     <div class="form-title">お問い合わせ内容<span class="required_content">必須</span></div>

--- a/app/views/contacts/index.html.erb
+++ b/app/views/contacts/index.html.erb
@@ -11,7 +11,7 @@
         <%= render "confirm_fields", form: form %>
         <div>
           <div class="mt-4"><%= form.button "戻る", name: "contact[confirmed]", value: "", class:"submit-btn" %></div>
-          <div><%= form.button "送信", name: "contact[confirmed]", value: "1", class:"submit-btn" %></div>
+          <div><%= form.button "送信", name: "contact[confirmed]", value: "1", data: { disable_with: "送信中..." }, class:"submit-btn" %></div>
         </div>
           <% else %>
         <%# 投稿画面 %>

--- a/app/views/contents/_form.html.erb
+++ b/app/views/contents/_form.html.erb
@@ -5,28 +5,28 @@
 
     <div>
       <h2 class="form-title">タイトル<span class="required_content">必須</span></h2>
-      <p><%= f.text_field :title, placeholder: "コンテンツ名(16文字以内)", class: "text-field"%></p>
+      <p><%= f.text_field :title, placeholder: "コンテンツ名(16文字以内)", required: true, class: "text-field"%></p>
     </div>
 
     <div>
       <h2 class="form-title">サブタイトル<span class="required_content">必須</span></h2>
-      <p><%= f.text_area :subtitle, placeholder: "サブタイトル(32文字以内)",class:"text-area" %></p>
+      <p><%= f.text_area :subtitle, placeholder: "サブタイトル(32文字以内)", required: true, class:"text-area" %></p>
     </div>
 
     <div>
       <h2 class="form-title">youtube_URL<span class="required_content">必須</span></h2>
       <span class="text-sm">Youtube上にアップロードされているページのURLを貼り付けて下さい</span>
-      <%= f.text_field :movie_url, placeholder: "(例) https://youtube.com/sample",class: "text-field"%>
+      <%= f.text_field :movie_url, placeholder: "(例) https://youtube.com/sample",required: true, class: "text-field"%>
     </div>
 
     <div>
       <h2 class="form-title">コメント<span class="required_content">必須</span></h2>
-      <p><%= f.text_area :comment, placeholder: "コンテンツに対するコンテンツ(32文字以内)",class:"text-area" %></p>
+      <p><%= f.text_area :comment, placeholder: "コンテンツに対するコンテンツ(32文字以内)",required: true, class:"text-area" %></p>
     </div>
 
     <div>
       <h2 class="form-title">ポイント<span class="required_content">必須</span></h2>
-      <p><%= f.text_area :point, placeholder: "コンテンツのポイント(32文字以内)",class:"text-area" %></p>
+      <p><%= f.text_area :point, placeholder: "コンテンツのポイント(32文字以内)",required: true, class:"text-area" %></p>
     </div>
 
     <!-- コンテンツタグ-->

--- a/app/views/contents/_form.html.erb
+++ b/app/views/contents/_form.html.erb
@@ -15,7 +15,7 @@
 
     <div>
       <h2 class="form-title">youtube_URL<span class="required_content">必須</span></h2>
-      <span class="text-sm">Youtube上にアップロードされているページのURLを貼り付けて下さい</span>
+      <span class="supplement_comment">Youtube上にアップロードされているページのURLを貼り付けて下さい</span>
       <%= f.text_field :movie_url, placeholder: "(例) https://youtube.com/sample",required: true, class: "text-field"%>
     </div>
 
@@ -30,7 +30,7 @@
     </div>
 
     <!-- コンテンツタグ-->
-    <div>
+    <div class="max-w-4xl mx-auto">
       <h2 class="form-title">タグ（3つまで）</h2>
 
       <div class="flex flex-wrap justify-start py-4 mb-8">

--- a/app/views/contents/_form.html.erb
+++ b/app/views/contents/_form.html.erb
@@ -46,7 +46,7 @@
     </div>
 
     <div class="my-16">
-      <%= f.submit "確定する", data: { confirm: '確定します。よろしいでしょうか？'}, class:"submit-btn" %>
+      <%= f.submit "確定する", data: { confirm: '確定します。よろしいでしょうか？', disable_with: "送信中..."}, class:"submit-btn" %>
     </div>
 
   </div>

--- a/app/views/contents/_make_card.html.erb
+++ b/app/views/contents/_make_card.html.erb
@@ -13,7 +13,7 @@
         <!-- 編集ボタン-->
         <%= link_to ">>編集", edit_make_path(make.id, params: { content_id: make.content.id }), method: :get, class: "admin-link" %>
         <!-- 削除ボタン-->
-        <%= link_to ">>削除", make_path(make.id), data: { confirm: '削除してもよろしいでしょうか？'}, method: :delete, class: "admin-link" %>
+        <%= link_to ">>削除", make_path(make.id), data: { confirm: '削除してもよろしいでしょうか？', disable_with: "送信中..."}, method: :delete, class: "admin-link" %>
       <% end %>
 
     </div>

--- a/app/views/contents/_material_card.html.erb
+++ b/app/views/contents/_material_card.html.erb
@@ -15,7 +15,7 @@
         <!-- 材料CRUD-->
         <% if admin_user? %>
           <%= link_to ">>編集", edit_material_path(material.id, params: { content_id: material.content.id }), method: :get, class: "admin-link" %>
-          <%= link_to ">>削除", material_path(material.id), data: { confirm: '削除してもよろしいでしょうか？'}, method: :delete, class: "admin-link" %>
+          <%= link_to ">>削除", material_path(material.id), data: { confirm: '削除してもよろしいでしょうか？', disable_with: "送信中..."}, method: :delete, class: "admin-link" %>
         <% end %>
       </div>
 

--- a/app/views/contents/_question_card.html.erb
+++ b/app/views/contents/_question_card.html.erb
@@ -18,7 +18,7 @@
     <% if question.user == current_user || admin_user? %>
       <% if question.response.nil? %>
       <div class="text-left p-4">
-        <%= link_to ">>削除", question_path(question), data: { confirm: '確定します。よろしいでしょうか？'}, method: :delete, class:"red-link" %>
+        <%= link_to ">>削除", question_path(question), data: { confirm: '確定します。よろしいでしょうか？', disable_with: "送信中..."}, method: :delete, class:"red-link" %>
       </div>
     <% end %>
 
@@ -43,7 +43,7 @@
       <% if admin_user? %>
         <div class="flex justify-end p-4">
           <div class= "px-4 mr-1 text-right"><%= link_to ">>編集", edit_response_path(question.response, question_id: question.id), class:"admin-link" %></div>
-          <div><%= link_to ">>削除", response_path(question.response), data: { confirm: '確定します。よろしいでしょうか？'}, method: :delete, class:"admin-link" %></div>
+          <div><%= link_to ">>削除", response_path(question.response), data: { confirm: '確定します。よろしいでしょうか？, disable_with: "送信中..."'}, method: :delete, class:"admin-link" %></div>
         </div>
       <% end %>
 

--- a/app/views/contents/_question_card.html.erb
+++ b/app/views/contents/_question_card.html.erb
@@ -1,7 +1,7 @@
-<div class="p-2 mb-4">
+<div class="p-4 mb-4 mx-4 max-w-4xl mx-auto">
 
   <!-- 質問-->
-  <div  class="border border-gray-300 rounded-lg mb-4">
+  <div  class="border bg-white rounded-lg mb-4">
     <!-- 質問ユーザー -->
     <div class="flex px-4 py-8">
       <%= image_tag question.user.thumbnail.thumb27.url, class:"rounded-full border border-gray-300"%>
@@ -27,7 +27,7 @@
 
 
   <!--返信-->
-  <div class="border bg-gray-100 rounded-lg">
+  <div class="border bg-blue-100 rounded-lg">
 
     <% if question.response.present?%> <%# 返信がある場合、返信を表示する%>
       <!-- DEKRIU情報 -->

--- a/app/views/contents/_question_form.html.erb
+++ b/app/views/contents/_question_form.html.erb
@@ -4,7 +4,7 @@
       <%= f.hidden_field :content_id, value: @content.id %>
 
       <div class="my-4">
-        <%= f.text_area :question_content ,placeholder: "100文字以内", maxlength:"100", class:"text-area" %>
+        <%= f.text_area :question_content ,placeholder: "100文字以内", maxlength:"100",required: true, class:"text-area" %>
       </div>
 
         <div class="my-4">

--- a/app/views/contents/_question_form.html.erb
+++ b/app/views/contents/_question_form.html.erb
@@ -8,7 +8,7 @@
       </div>
 
         <div class="my-4">
-          <%= f.submit "質問する", data: { confirm: '確定します。よろしいでしょうか？'}, class:"submit-btn"%>
+          <%= f.submit "質問する",data: { confirm: '確定します。よろしいでしょうか？', disable_with: "送信中..."}, class:"submit-btn"%>
         </div>
      </div>
 

--- a/app/views/contents/_question_form.html.erb
+++ b/app/views/contents/_question_form.html.erb
@@ -1,10 +1,10 @@
   <%= form_with model: @question, local: true do |f| %>
-    <div class="form-body">
+    <div class="form-body p-4">
 
       <%= f.hidden_field :content_id, value: @content.id %>
 
-      <div>
-        <p><%= f.text_area :question_content, placeholder: "100文字以内", maxlength:"100", class:"text-area" %></p>
+      <div class="my-4">
+        <%= f.text_area :question_content ,placeholder: "100文字以内", maxlength:"100", class:"text-area" %>
       </div>
 
         <div class="my-4">

--- a/app/views/contents/show.html.erb
+++ b/app/views/contents/show.html.erb
@@ -7,7 +7,7 @@
   <div>
     <%= link_to ">>編集", edit_content_path, class:"admin-link mr-4" %>
     <%# TODO: アラートにデザインを当てる %>
-    <%= link_to ">>削除", content_path(@content), data: { confirm: '削除してもよろしいでしょうか？'}, method: :delete, class:"admin-link" %>
+    <%= link_to ">>削除", content_path(@content), data: { confirm: '削除してもよろしいでしょうか？', disable_with: "送信中..."}, method: :delete, class:"admin-link" %>
   </div>
   <% end %>
 </div>

--- a/app/views/contents/show.html.erb
+++ b/app/views/contents/show.html.erb
@@ -113,23 +113,29 @@
 </div>
 
 
-<!-- 質問 -->
-<h2 class="h2 py-4">質問する</h2>
-<!-- 質問フォーム -->
-<% if user_signed_in? %>
-  <% if current_user.general? %>
-    <%= render "question_form" %>
-  <% else %>
-    <p>管理者は質問できません。</p>
-  <% end %>
-<% else %>
-  <p>ログインすると、質問ができます</p>
-<% end %>
-<br/>
-
 <!-- 質問と返信 -->
-<h2 class="h2 mt-8 mb-4">質問</h2>
-<%= render partial: "question_card", collection: @questions, as: "question" %>
+<div class="py-4 my-4 bg-dekiru-base">
+
+  <!-- 質問フォーム -->
+  <h2 class="h2 mt-8 mb-4">質問</h2>
+  <%= render partial: "question_card", collection: @questions, as: "question" %>
+  <%# TODO: jqueryでアコーディオンを検討(長くなるので) %>
+
+  <!-- 質問 -->
+  <h2 class="h2 py-4">質問する</h2>
+  <!-- 質問フォーム -->
+  <div>
+  <% if user_signed_in? %>
+    <% if current_user.general? %>
+      <%= render "question_form" %>
+    <% else %>
+      <p>管理者は質問できません。</p>
+    <% end %>
+  <% else %>
+    <p>ログインすると、質問ができます</p>
+  <% end %>
+  </div>
+
+</div>
 
 
-<%# TODO: jqueryでアコーディオンを検討(長くなるので) %>

--- a/app/views/layouts/_content_tag.html.erb
+++ b/app/views/layouts/_content_tag.html.erb
@@ -5,7 +5,7 @@
     <% if admin_user? %>
       <%# TODO: home#indexの場合、非表示にしたい。%>
     　<%= link_to ">>編集", edit_tag_master_path(tag.id) , class:"admin-link" %>
-  　  <%= link_to ">>削除", tag_master_path(tag.id), data: { confirm: '削除してもよろしいでしょうか？'}, method: :delete, class:"admin-link" %>
+  　  <%= link_to ">>削除", tag_master_path(tag.id), data: { confirm: '削除してもよろしいでしょうか？', disable_with: "送信中..."}, method: :delete, class:"admin-link" %>
     <% end %>
   </div>
 <% end %>

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -1,4 +1,4 @@
-<footer class="bg-dekiru-base py-8 text-center">
+<footer class="bg-dekiru-base py-8 text-center border">
 
   <div class="p-4 md:flex md:mx-20 xl:mx-80">
 

--- a/app/views/layouts/_search_form.html.erb
+++ b/app/views/layouts/_search_form.html.erb
@@ -1,7 +1,7 @@
 <!-- 検索フォーム -->
 <div>
   <%= search_form_for @q, url: search_contents_path do |f| %>
-    <%= f.search_field :title_or_subtitle_or_comment_or_tag_masters_tag_name_cont, class:"text-filed bg-gray-200 rounded-full p-2", placeholder:"キーワードを入力"%>
+    <%= f.search_field :title_or_subtitle_or_comment_or_tag_masters_tag_name_cont, placeholder:"キーワードを入力", class:"text-filed bg-gray-200 rounded-full p-2" %>
     <%# これをアイコンにする%>
     <%= f.submit class: "bg-white"%>
   <% end %>

--- a/app/views/makes/_form.html.erb
+++ b/app/views/makes/_form.html.erb
@@ -7,7 +7,7 @@
     
     <div>
       <h2 class="form-title">作り方<span class="required_content">必須</span></h2>
-      <p><%= f.text_area :detail, placeholder: "作り方(32文字以内)", class:"text-area" %></p>
+      <p><%= f.text_area :detail, placeholder: "作り方(32文字以内)",required: true, class:"text-area" %></p>
     </div>
     
     <div>

--- a/app/views/makes/_form.html.erb
+++ b/app/views/makes/_form.html.erb
@@ -11,7 +11,7 @@
     </div>
     
     <div>
-      <%= f.submit "確定する", data: { confirm: '確定します。よろしいでしょうか？'}, class:"submit-btn" %>
+      <%= f.submit "確定する", data: { confirm: '確定します。よろしいでしょうか？', disable_with: "送信中..."}, class:"submit-btn" %>
     </div>
     
     </div>

--- a/app/views/materials/_form.html.erb
+++ b/app/views/materials/_form.html.erb
@@ -22,7 +22,7 @@
   
   
     <div>
-      <%= f.submit "確定する", data: { confirm: '確定します。よろしいでしょうか？'}, class:"submit-btn" %>
+      <%= f.submit "確定する", data: { confirm: '確定します。よろしいでしょうか？', disable_with: "送信中..."}, class:"submit-btn" %>
     </div>
   
   </div>

--- a/app/views/materials/_form.html.erb
+++ b/app/views/materials/_form.html.erb
@@ -7,17 +7,17 @@
     
     <div>
       <h2 class="form-title">材料名<span class="required_content">必須</span></h2>
-      <p><%= f.text_field :name ,placeholder: "材料の名前(16文字以内)", class: "text-field"%></p>
+      <p><%= f.text_field :name ,placeholder: "材料の名前(16文字以内)",required: true, class: "text-field"%></p>
     </div>
   
     <div>
       <h2 class="form-title">分量<span class="required_content">必須</span></h2>
-      <p><%= f.text_field :amount, placeholder: "(例) 1", class: "text-field"%></p>
+      <p><%= f.text_field :amount, placeholder: "(例) 1",required: true, class: "text-field"%></p>
     </div>
   
     <div>
       <h2 class="form-title">単位<span class="required_content">必須</span></h2>
-      <p><%= f.text_field :unit , placeholder: "(例) 枚",class: "text-field"%></p>
+      <p><%= f.text_field :unit , placeholder: "(例) 枚",required: true, class: "text-field"%></p>
     </div>
   
   

--- a/app/views/responses/_form.html.erb
+++ b/app/views/responses/_form.html.erb
@@ -22,7 +22,7 @@
       </div>
 
       <div>
-        <%= f.submit "確定する", data: { confirm: '確定します。よろしいでしょうか？'}, class:"submit-btn" %>
+        <%= f.submit "確定する", data: { confirm: '確定します。よろしいでしょうか？', disable_with: "送信中..."}, class:"submit-btn" %>
       </div>
     </div>
 

--- a/app/views/reviews/new.html.erb
+++ b/app/views/reviews/new.html.erb
@@ -19,7 +19,7 @@
     </div>
     
     <div>
-      <%= f.submit "確定する", data: { confirm: '確定します。よろしいでしょうか？'}, class:"submit-btn" %>
+      <%= f.submit "確定する", data: { confirm: '確定します。よろしいでしょうか？', disable_with: "送信中..."}, class:"submit-btn" %>
     </div>
   
   </div>

--- a/app/views/reviews/new.html.erb
+++ b/app/views/reviews/new.html.erb
@@ -8,12 +8,14 @@
 
     <div>
       <div class="form-title">写真<span class="required_content">必須</span></div>
-      <%= f.file_field :image, accept: "image/png,image/jpeg" %>
+      <div class="mx-auto max-w-4xl">
+        <%= f.file_field :image, accept: "image/png,image/jpeg", class:"block"%>
+      </div>
     </div>
   
     <div>
       <div class="form-title">レビュー<span class="required_content">必須</span></div>
-      <p><%= f.text_area :comment, placeholder: "レビュー内容(500文字以内)",required: true, class:"text-area" %></p>
+      <%= f.text_area :comment, placeholder: "レビュー内容(500文字以内)",required: true, class:"text-area" %>
     </div>
     
     <div>

--- a/app/views/reviews/new.html.erb
+++ b/app/views/reviews/new.html.erb
@@ -13,7 +13,7 @@
   
     <div>
       <div class="form-title">レビュー<span class="required_content">必須</span></div>
-      <p><%= f.text_area :comment, placeholder: "レビュー内容(500文字以内)", class:"text-area" %></p>
+      <p><%= f.text_area :comment, placeholder: "レビュー内容(500文字以内)",required: true, class:"text-area" %></p>
     </div>
     
     <div>

--- a/app/views/tag_masters/_form.html.erb
+++ b/app/views/tag_masters/_form.html.erb
@@ -12,7 +12,7 @@
     <%#= f.text_area :detail %>
     
     <div>
-      <%= f.submit "確定する", data: { confirm: '確定します。よろしいでしょうか？'}, class:"submit-btn" %>
+      <%= f.submit "確定する", data: { confirm: '確定します。よろしいでしょうか？', disable_with: "送信中..."}, class:"submit-btn" %>
     </div>
   </div>
 <% end %>

--- a/app/views/tag_masters/_form.html.erb
+++ b/app/views/tag_masters/_form.html.erb
@@ -5,7 +5,7 @@
   
     <div>
       <h2 class ="form-title">タグの名前<span class="required_content">必須</span></h2>
-      <p><%= f.text_field :tag_name, class: "text-field", placeholder: "タグ名(10文字以内)" %></p>
+      <p><%= f.text_field :tag_name, placeholder: "タグ名(10文字以内)",required: true, class: "text-field" %></p>
     </div>
     
     <!-- タグタイプ -->

--- a/app/views/users/confirmations/new.html.erb
+++ b/app/views/users/confirmations/new.html.erb
@@ -9,7 +9,7 @@
   </div>
 
   <div class="actions">
-    <%= f.submit "Resend confirmation instructions", class:"submit-btn" %>
+    <%= f.submit "Resend confirmation instructions", data: { disable_with: "送信中..." } class:"submit-btn" %>
   </div>
 <% end %>
 

--- a/app/views/users/passwords/edit.html.erb
+++ b/app/views/users/passwords/edit.html.erb
@@ -18,7 +18,7 @@
   </div>
 
   <div class="actions">
-    <%= f.submit "Change my password", class:"submit-btn" %>
+    <%= f.submit "Change my password",data: { disable_with: "送信中..." }, class:"submit-btn" %>
   </div>
 <% end %>
 

--- a/app/views/users/passwords/new.html.erb
+++ b/app/views/users/passwords/new.html.erb
@@ -9,7 +9,7 @@
   </div>
 
   <div class="actions">
-    <%= f.submit "メールを送信する", class:"submit-btn" %>
+    <%= f.submit "メールを送信する", data: { confirm: '確定します。よろしいでしょうか？', disable_with: "送信中..." }, class:"submit-btn" %>
   </div>
 <% end %>
 

--- a/app/views/users/registrations/edit.html.erb
+++ b/app/views/users/registrations/edit.html.erb
@@ -10,12 +10,12 @@
     
     <div class="field">
       <div class="form-title">ユーザー名<span class="required_content">必須</span></div>
-      <%= f.text_field :name, placeholder: "名前入力(16文字以内)", class: "text-field"%>
+      <%= f.text_field :name, placeholder: "名前入力(16文字以内)",required: true, class: "text-field"%>
     </div>
   
     <div class="field">
       <div class="form-title">メールアドレス<span class="required_content">必須</span></div>
-      <%= f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "例：sample@gmail.com", class: "text-field" %>
+      <%= f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "例：sample@gmail.com",required: true, class: "text-field" %>
     </div>
   
   
@@ -33,7 +33,7 @@
       <%= f.label "新しいパスワード【変更する場合は入力】",class: "form-title" %>
       <%#= f.label :password %><!-- <br /> -->
       <%= f.password_field :password, autocomplete: "new-password", placeholder: "例：pass2021", class: "text-field" %>
-      <span>(８文字以上１６文字以内、有効な記号　- _ @)</span>
+      <span class="text-sm text-left">(８文字以上１６文字以内、有効な記号　- _ @)</span>
     </div>
   
     <div class="field">
@@ -46,7 +46,7 @@
       <%#= f.label :current_password %><!-- <br /> -->
       <%# TODO: 必須のマークを変更したい %>
       <div class="form-title">現在のパスワード<span class="required_content">必須</span></div>
-      <%= f.password_field :current_password, autocomplete: "current-password", placeholder: "現在のパスワード", class: "text-field" %>
+      <%= f.password_field :current_password, autocomplete: "current-password", placeholder: "現在のパスワード",required: true, class: "text-field" %>
     </div>
   
     <div class="actions">

--- a/app/views/users/registrations/edit.html.erb
+++ b/app/views/users/registrations/edit.html.erb
@@ -1,4 +1,5 @@
 <%# TODO: ルーディングを調整すること%>
+<div class="p-4 mb-60">
 
 <h2 class="h2 pt-8 pb-4">アカウント編集</h2>
 <%= link_to ">>マイページへ戻る", mypage_path(current_user), class:"blue-link"%>
@@ -32,8 +33,8 @@
     <div class="field">
       <%= f.label "新しいパスワード【変更する場合は入力】",class: "form-title" %>
       <%#= f.label :password %><!-- <br /> -->
-      <%= f.password_field :password, autocomplete: "new-password", placeholder: "例：pass2021", class: "text-field" %>
-      <span class="text-sm text-left">(８文字以上１６文字以内、有効な記号　- _ @)</span>
+      <div><%= f.password_field :password, autocomplete: "new-password", placeholder: "例：pass2021", class: "text-field" %></div>
+      <span class="supplement_comment">(８文字以上１６文字以内、有効な記号　- _ @)</span>
     </div>
   
     <div class="field">
@@ -51,11 +52,9 @@
   
     <div class="actions">
       <%= f.submit "確定する", class:"submit-btn" %>
-      <%#= f.submit "Update" %>
     </div>
-
-  </div>
-<% end %>
+  <% end %>
+</div>
 
 <%# アカウント削除ボタンを導入する場合は以下をコメントアウト %>
 <%#= button_to "このアカウント削除", registration_path(resource_name), data: { confirm: "アカウントを削除しますか？" }, method: :delete %>

--- a/app/views/users/registrations/edit.html.erb
+++ b/app/views/users/registrations/edit.html.erb
@@ -49,7 +49,7 @@
       </div>
 
       <div class="actions">
-        <%= f.submit "確定する", class:"submit-btn" %>
+        <%= f.submit "確定する",data: { confirm: '確定します。よろしいでしょうか？', disable_with: "送信中..." }, class:"submit-btn" %>
       </div>
 
     </div>
@@ -58,6 +58,6 @@
 </div>
 
 <%# アカウント削除ボタンを導入する場合は以下をコメントアウト %>
-<%#= button_to "このアカウント削除", registration_path(resource_name), data: { confirm: "アカウントを削除しますか？" }, method: :delete %>
+<%#= button_to "このアカウント削除", registration_path(resource_name), data: { confirm: "アカウントを削除しますか？" , disable_with: "送信中..."}, method: :delete %>
 <%#= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete %>
 

--- a/app/views/users/registrations/edit.html.erb
+++ b/app/views/users/registrations/edit.html.erb
@@ -1,5 +1,5 @@
 <%# TODO: ルーディングを調整すること%>
-<div class="p-4 mb-60">
+<div class="p-4 mb-20">
 
 <h2 class="h2 pt-8 pb-4">アカウント編集</h2>
 <%= link_to ">>マイページへ戻る", mypage_path(current_user), class:"blue-link"%>
@@ -7,53 +7,54 @@
 <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
   <div class="form-body">
 
-    <%= render "users/shared/error_messages", resource: resource %>
-    
-    <div class="field">
-      <div class="form-title">ユーザー名<span class="required_content">必須</span></div>
-      <%= f.text_field :name, placeholder: "名前入力(16文字以内)",required: true, class: "text-field"%>
-    </div>
-  
-    <div class="field">
-      <div class="form-title">メールアドレス<span class="required_content">必須</span></div>
-      <%= f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "例：sample@gmail.com",required: true, class: "text-field" %>
-    </div>
-  
-  
-    <div class="field">
-      <%= f.label :thumbnail, class: "form-title" %>
-      <%= f.file_field :thumbnail, accept: "image/png,image/jpeg", class: "text-field" %>
-    </div>
-  
-  
-    <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
-      <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
-    <% end %>
-  
-    <div class="field">
-      <%= f.label "新しいパスワード【変更する場合は入力】",class: "form-title" %>
-      <%#= f.label :password %><!-- <br /> -->
-      <div><%= f.password_field :password, autocomplete: "new-password", placeholder: "例：pass2021", class: "text-field" %></div>
-      <span class="supplement_comment">(８文字以上１６文字以内、有効な記号　- _ @)</span>
-    </div>
-  
-    <div class="field">
-      <%= f.label "新しいパスワード(確認用)【変更する場合は入力】",class: "form-title" %>
-      <%#= f.label :password_confirmation %><!-- <br /> -->
-      <%= f.password_field :password_confirmation, autocomplete: "new-password",placeholder: "例：pass2021", class: "text-field" %>
-    </div>
-  
-    <div class="field">
-      <%#= f.label :current_password %><!-- <br /> -->
-      <%# TODO: 必須のマークを変更したい %>
-      <div class="form-title">現在のパスワード<span class="required_content">必須</span></div>
-      <%= f.password_field :current_password, autocomplete: "current-password", placeholder: "現在のパスワード",required: true, class: "text-field" %>
-    </div>
-  
-    <div class="actions">
-      <%= f.submit "確定する", class:"submit-btn" %>
+      <%= render "users/shared/error_messages", resource: resource %>
+
+      <div class="field">
+        <div class="form-title">ユーザー名<span class="required_content">必須</span></div>
+        <%= f.text_field :name, placeholder: "名前入力(16文字以内)",required: true, class: "text-field"%>
+      </div>
+
+      <div class="field">
+        <div class="form-title">メールアドレス<span class="required_content">必須</span></div>
+        <%= f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "例：sample@gmail.com",required: true, class: "text-field" %>
+      </div>
+
+      <div class="field">
+        <%= f.label :thumbnail, class: "form-title" %>
+        <%= f.file_field :thumbnail, accept: "image/png,image/jpeg", class: "text-field" %>
+      </div>
+
+      <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
+        <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
+      <% end %>
+
+      <div class="field">
+        <%= f.label "新しいパスワード【変更する場合は入力】",class: "form-title" %>
+        <%#= f.label :password %><!-- <br /> -->
+        <div><%= f.password_field :password, autocomplete: "new-password", placeholder: "例：pass2021", class: "text-field" %></div>
+        <span class="supplement_comment">(８文字以上１６文字以内、有効な記号　- _ @)</span>
+      </div>
+
+      <div class="field">
+        <%= f.label "新しいパスワード(確認用)【変更する場合は入力】",class: "form-title" %>
+        <%#= f.label :password_confirmation %><!-- <br /> -->
+        <%= f.password_field :password_confirmation, autocomplete: "new-password",placeholder: "例：pass2021", class: "text-field" %>
+      </div>
+
+      <div class="field">
+        <%#= f.label :current_password %><!-- <br /> -->
+        <%# TODO: 必須のマークを変更したい %>
+        <div class="form-title">現在のパスワード<span class="required_content">必須</span></div>
+        <%= f.password_field :current_password, autocomplete: "current-password", placeholder: "現在のパスワード",required: true, class: "text-field" %>
+      </div>
+
+      <div class="actions">
+        <%= f.submit "確定する", class:"submit-btn" %>
+      </div>
+
     </div>
   <% end %>
+
 </div>
 
 <%# アカウント削除ボタンを導入する場合は以下をコメントアウト %>

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -17,7 +17,7 @@
     <div class="field">
       <div class="form-title">パスワード(8文字以上)<span class="required_content">必須</span></div>
       <%= f.password_field :password, autocomplete: "new-password", placeholder: "例：pass2021", required: true, class: "text-field" %>
-      <span>(８文字以上１６文字以内、有効な記号　- _ @)</span>
+      <span class="supplement_comment">(８文字以上１６文字以内、有効な記号　- _ @)</span>
     </div>
 
     <div class="field">

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -26,7 +26,7 @@
     </div>
   
     <div class="actions my-4">
-      <%= f.submit "作成する", class:"submit-btn" %>
+      <%= f.submit "作成する", data: { confirm: '確定します。よろしいでしょうか？', disable_with: "作成中..." }, class:"submit-btn" %>
     </div>
   </div>
 <% end %>

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -6,23 +6,23 @@
   
     <div class="field">
       <div class="form-title">ユーザー名<span class="required_content">必須</span></div>
-      <%= f.text_field :name, placeholder: "名前入力(16文字以内)", class: "text-field"%>
+      <%= f.text_field :name, placeholder: "名前入力(16文字以内)", required: true, class: "text-field"%>
     </div>
   
     <div class="field">
       <div class="form-title">メールアドレス<span class="required_content">必須</span></div>
-      <%= f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "例：sample@gmail.com", class: "text-field" %>
+      <%= f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "例：sample@gmail.com", required: true, class: "text-field" %>
     </div>
   
     <div class="field">
       <div class="form-title">パスワード(8文字以上)<span class="required_content">必須</span></div>
-      <%= f.password_field :password, autocomplete: "new-password", placeholder: "例：pass2021", class: "text-field" %>
+      <%= f.password_field :password, autocomplete: "new-password", placeholder: "例：pass2021", required: true, class: "text-field" %>
       <span>(８文字以上１６文字以内、有効な記号　- _ @)</span>
     </div>
 
     <div class="field">
     <div class="form-title">確認用パスワード(8文字以上)<span class="required_content">必須</span></div>
-      <%= f.password_field :password_confirmation, autocomplete: "new-password",placeholder: "例：pass2021", class: "text-field" %>
+      <%= f.password_field :password_confirmation, autocomplete: "new-password",placeholder: "例：pass2021", required: true, class: "text-field" %>
     </div>
   
     <div class="actions my-4">

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -1,16 +1,16 @@
-<h2 class="h2">ログイン</h2>
+<h2 class="h2 my-8">ログイン</h2>
 
 <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
-<div class="form-body">
+<div class="form-body py-8">
   
   <div class="field">
-    <%= f.label :email, class:"form-title"%><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email", class:"login-field" %>
+    <h2 class="form-title">メールアドレス<span class="required_content">必須</span></h2>
+    <%= f.email_field :email, autofocus: true, autocomplete: "email",required: true, class:"login-field" %>
   </div>
 
   <div class="field">
-    <%= f.label :password, class:"form-title" %><br />
-    <%= f.password_field :password, autocomplete: "current-password", class:"login-field" %>
+    <h2 class="form-title">パスワード<span class="required_content">必須</span></h2>
+    <%= f.password_field :password, autocomplete: "current-password",required: true, class:"login-field" %>
   </div>
 
   <% if devise_mapping.rememberable? %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,4 +1,4 @@
-<div class="text-center pt-16 pb-32 border border-red-500">
+<div class="text-center pt-16 pb-32">
   <!-- タイトル-->
   <h2 class="h2 py-8">MyPage</h2>
 
@@ -28,7 +28,7 @@
 
   <!-- ログアウト-->
   <div class="my-8 text-center">
-    <%= link_to destroy_user_session_path, method: :delete, data: { confirm: "ログアウトしますか？" }, class: "red-link w-40 border border-red-500 py-2 px-4 w-32 hover:bg-red-500 hover:text-white" do%>
+    <%= link_to destroy_user_session_path, method: :delete, data: { confirm: "ログアウトしますか？", disable_with: "送信中..." }, class: "red-link w-40 border border-red-500 py-2 px-4 w-32 hover:bg-red-500 hover:text-white" do%>
       <button class="w-32">ログアウト</button>
     <% end %>
   </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,4 +1,4 @@
-<div class="text-center pt-16 pb-32">
+<div class="text-center pt-16 pb-32 border border-red-500">
   <!-- タイトル-->
   <h2 class="h2 py-8">MyPage</h2>
 
@@ -18,14 +18,14 @@
       <button class="w-32">お気に入り一覧</button>
     <% end %>
   </div>
-  
+
   <!-- アカウント編集-->
   <div class="my-8 text-center">
     <%= link_to edit_user_registration_path(current_user), class:"blue-link border border-blue-500  py-2 px-4 hover:bg-dekiru-blue hover:text-white" do %>
       <button class="w-32">アカウント編集</button>
     <% end %>
   </div>
-  
+
   <!-- ログアウト-->
   <div class="my-8 text-center">
     <%= link_to destroy_user_session_path, method: :delete, data: { confirm: "ログアウトしますか？" }, class: "red-link w-40 border border-red-500 py-2 px-4 w-32 hover:bg-red-500 hover:text-white" do%>
@@ -33,35 +33,29 @@
     <% end %>
   </div>
 
-
-
-  
   <!-- 管理者専用-->
   <% if admin_user? %>
     <div class="text-left p-8">
       <h2 class="text-pink-500">管理者専用</h2>
       
-  
       <h2 class="h2 py-8">1.タグ一覧</h2>
-      <%= link_to ">>追加", new_tag_master_path, class:"admin-link" %>
-      <%= render partial: "layouts/content_tag", collection: @content_tags, as: "tag" %>
-    
-  
+      <div>
+        <%= link_to ">>追加", new_tag_master_path, class:"admin-link" %>
+        <%= render partial: "layouts/content_tag", collection: @content_tags, as: "tag" %>
+      </div>
+
       <h2 class="h2 py-8">2.カテゴリー作成</h2>
       <div>
         <%= link_to ">>追加", new_category_path, class:"admin-link" %>
       </div>
-    
-  
+
       <div>
         <h2 class="h2 py-8">3.コンテンツ作成</h2>
         <!-- 新規作成リンク(管理者のみ) -->
         <div><%= link_to ">>新規作成",new_content_path, class:"admin-link" %></div>
       </div>
-      
-      
-  
-    <% end %>
-  
-  
-  </div>  
+
+    </div>
+  <% end %>
+
+  </div>


### PR DESCRIPTION
## 実装の目的と概要
- フォームのレイアウトを実装
## 実装内容(技術的な点を記載)
- [x] フォームのレイアウト崩れを実装
- [x] フォームにfocueを実装
- [x] `desable_with`を実装
- [x] `required: true`を実装
- [x] `resize-none`を実装

## スクリーンショット（画面レイアウトを変更した場合）
<img width="1680" alt="スクリーンショット 2021-06-09 14 50 13" src="https://user-images.githubusercontent.com/64491435/121302920-5ddac480-c935-11eb-8e09-145c0b4f3444.png">
<img width="1680" alt="スクリーンショット 2021-06-09 14 49 10" src="https://user-images.githubusercontent.com/64491435/121302927-616e4b80-c935-11eb-98c0-d47d14608ac6.png">

## 参考資料
- [フォームの必須入力項目を指定する](https://gray-code.com/html_css/specify-required-input-items-of-the-form/)
- [[Rails]submitタグにつけておきたいdisable_withオプション](https://qiita.com/sue738/items/09f569bdc3a73d26df88)
## チェックリスト

- [x] ローカル環境での動作確認をしたか（影響し得る範囲も含めて）
- [x] rubocopを実行して警告が出力されていないか
- [x] GitHub で ファイル差分（Files changed）を確認し、内容が合っているか。不要なファイルに差分がでていないか
- [x] テストでエラーが発生していないか
