### PR TITLE
[レイアウト]エラーメッセージにレイアウトを実装

### DIFF
--- a/app/views/layouts/_error_messages.html.erb
+++ b/app/views/layouts/_error_messages.html.erb
@@ -1,8 +1,23 @@
-
 <% if model.errors.any? %>
-  <ul>
+  <div class="mt-10 mb-20">
+  <div class="mx-auto max-w-4xl mb-10">
+      <%= I18n.t("errors.messages.not_saved",
+                 count: model.errors.count,
+                 resource: model.class.model_name.human.downcase)
+       %>
     <% model.errors.full_messages.each.each do |message| %>
-      <li><%= message %></li>
+     <div class="flex flex-col space-y-3 m-1">
+      <div class="bg-red-100 p-5 w-full border-l-4 border-red-700">
+        <div class="flex space-x-3">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="flex-none fill-current text-red-500 h-4 w-4">
+        <path d="M12 0c-6.627 0-12 5.373-12 12s5.373 12 12 12 12-5.373 12-12-5.373-12-12-12zm4.597 17.954l-4.591-4.55-4.555 4.596-1.405-1.405 4.547-4.592-4.593-4.552 1.405-1.405 4.588 4.543 4.545-4.589 1.416 1.403-4.546 4.587 4.592 4.548-1.403 1.416z" /></svg>
+          <div class="flex-1 leading-tight text-sm text-red-700">
+            <li class="block text-left"><%= message %></li>
+          </div>
+        </div>
+      </div>
+    </div>
     <% end %>
-  </ul>
+  </div>
+  </div>
 <% end %>

--- a/app/views/users/shared/_error_messages.html.erb
+++ b/app/views/users/shared/_error_messages.html.erb
@@ -1,15 +1,23 @@
 <% if resource.errors.any? %>
-  <div id="error_explanation">
-    <h2 class="h2 py-8">
+  <div class="mt-10 mb-20">
+    <div class="mx-auto max-w-4xl mb-10">
       <%= I18n.t("errors.messages.not_saved",
-                 count: resource.errors.count,
-                 resource: resource.class.model_name.human.downcase)
-       %>
-    </h2>
-    <ul>
+                   count: resource.errors.count,
+                   resource: resource.class.model_name.human.downcase)
+         %>
       <% resource.errors.full_messages.each do |message| %>
-        <li><%= message %></li>
+        <div class="flex flex-col space-y-3 m-1">
+          <div class="bg-red-100 p-5 w-full border-l-4 border-red-700">
+            <div class="flex space-x-3">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="flex-none fill-current text-red-500 h-4 w-4">
+            <path d="M12 0c-6.627 0-12 5.373-12 12s5.373 12 12 12 12-5.373 12-12-5.373-12-12-12zm4.597 17.954l-4.591-4.55-4.555 4.596-1.405-1.405 4.547-4.592-4.593-4.552 1.405-1.405 4.588 4.543 4.545-4.589 1.416 1.403-4.546 4.587 4.592 4.548-1.403 1.416z" /></svg>
+              <div class="flex-1 leading-tight text-sm text-red-700">
+                <li class="block text-left"><%= message %></li>
+              </div>
+            </div>
+          </div>
+        </div>
       <% end %>
-    </ul>
+    </div>
   </div>
 <% end %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -14,6 +14,7 @@ ja:
         amount: 量
         unit: 単位
       category:
+        category: カテゴリー
         name: カテゴリー名
       user:
         name: ユーザー名
@@ -30,3 +31,13 @@ ja:
       contact:
         title: お問い合わせタイトル
         content: お問い合わせ内容
+    models:
+      make: 作り方
+      material: 材料
+      category: カテゴリー
+      user: ユーザー
+      review: レビュー
+      question: 質問
+      response: 返信
+      tag_master: タグ
+      contact: お問い合わせ


### PR DESCRIPTION
## 実装の目的と概要
- エラーメッセージにレイアウトを実装
## 実装内容(技術的な点を記載)
- エラーメッセージにレイアウトを実装

## スクリーンショット（画面レイアウトを変更した場合）
<img width="834" alt="スクリーンショット 2021-06-09 16 14 56" src="https://user-images.githubusercontent.com/64491435/121312058-f70ed880-c93f-11eb-92f2-c5287ed2af06.png">


## チェックリスト

- [x] ローカル環境での動作確認をしたか（影響し得る範囲も含めて）
- [x] rubocopを実行して警告が出力されていないか
- [x] GitHub で ファイル差分（Files changed）を確認し、内容が合っているか。不要なファイルに差分がでていないか
- [x] テストでエラーが発生していないか
