### PR TITLE
[レイアウト]ボタンのスタイルの共通化

### DIFF
--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -9,37 +9,36 @@
     @apply text-2xl text-dekiru-font;
   }
   h2 {
-    @apply text-lg text-dekiru-font font-medium;
+    @apply text-2xl text-dekiru-font font-medium;
   }
 }
 
 //************ボタン**************//
-//mailボタン
-// TODO: hover用の色を作成すること
+//ベース
+.base_btn {
+ @apply text-white font-bold py-2 px-6 my-8 rounded-lg focus:outline-none shadow-lg 
+}
+
+//背景色・hover時の背景色
 .blue-btn {
-  @apply bg-dekiru-blue hover:bg-dekiru-light_blue text-white font-bold py-2 px-4 rounded-lg
+  @apply base_btn bg-dekiru-blue hover:bg-dekiru-light_blue
 }
 
-//deleteボタン
-// TODO: 色を検討する
 .red-btn {
-  @apply bg-red-500 hover:bg-red-700 text-white font-bold py-2 px-4 rounded-lg
+  @apply base_btn bg-red-500 hover:bg-red-700
 }
 
-//詳細遷移ボタン
-// TODO: 色を検討する
-.show-btn {
-  @apply bg-green-500 hover:bg-green-700 text-white font-bold py-2 px-4 rounded-full
+.submit-btn {
+  @apply base_btn bg-green-500 hover:bg-green-700 
 }
 
 // お気に入りボタン
-// TODO: 色を検討する
 .favorite-btn {
-  @apply text-white bg-green-500 hover:bg-green-700 text-white font-bold py-2 px-4 rounded-full
+  @apply text-white bg-green-500 hover:bg-green-700 text-white font-bold py-2 px-4 rounded-full my-4
 }
 
 .no-favorite-btn {
-  @apply text-green-500 border border-green-500 hover:bg-green-700 font-bold py-2 px-4 rounded-full
+  @apply text-green-500 border border-green-500 hover:bg-green-700 font-bold py-2 px-4 rounded-full 
 }
 
 //カテゴリータグ
@@ -49,19 +48,15 @@
 
 //コンテンツタグ
 .content-tag-btn {
-  @apply text-white bg-dekiru-keyword border-0 m-1 py-2 px-6 focus:outline-none text-lg
+  @apply text-white bg-dekiru-keyword hover:bg-green-400 border-0 m-1 py-2 px-6 focus:outline-none text-lg
 }
 
-//TOOD: 色を検討する,hoverも同様
-.submit-btn {
-  @apply text-white bg-green-500 py-2 px-6 m-4 focus:outline-none hover:bg-pink-600 rounded text-lg rounded-full
-}
 
 //************リンク**************//
 
 //mailCRUDリンク
 .blue-link {
-  @apply text-dekiru-blue text-sm
+  @apply text-dekiru-blue text-sm hover:text-dekiru-light_blue
 }
 
 //削除リンク

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -2,18 +2,18 @@
 @import "tailwindcss/components";
 @import "tailwindcss/utilities";
 
-//************文字**************//
-.h1 {
-  @apply text-4xl text-dekiru-font
-}
 
-.h2 {
-  @apply text-2xl text-dekiru-font font-medium
+//************ BASE **************//
+@layer base {
+  h1 {
+    @apply text-2xl text-dekiru-font;
+  }
+  h2 {
+    @apply text-lg text-dekiru-font font-medium;
+  }
 }
 
 //************ボタン**************//
-
-
 //mailボタン
 // TODO: hover用の色を作成すること
 .blue-btn {

--- a/app/views/categories/edit.html.erb
+++ b/app/views/categories/edit.html.erb
@@ -1,4 +1,4 @@
-<h2 class="h2 py-8">カテゴリー編集</h2>
+<h1 class="py-8">カテゴリー編集</h1>
 
 <%= link_to "カテゴリー一覧へ戻る", categories_path %>
 

--- a/app/views/categories/index.html.erb
+++ b/app/views/categories/index.html.erb
@@ -1,5 +1,5 @@
 <div class="my-8">
-  <h2 class="h2 py-8">カテゴリー一覧画面</h2>
+  <h1 class="py-8">カテゴリー一覧画面</h1>
   <div class="pt-16 pb-32">
     <div class="flex justify-start flex-wrap my-2">
       <%= render partial: "category_card", collection: @categories, as: "category" %>

--- a/app/views/categories/new.html.erb
+++ b/app/views/categories/new.html.erb
@@ -1,4 +1,4 @@
-<h2 class="h2 mt-8 mb-2">カテゴリー作成</h2>
+<h1 class="mt-8 mb-2">カテゴリー作成</h1>
 <%= link_to ">>マイページへ戻る", mypage_path(current_user), class:"blue-link" %>
 
 <%= render "form"%>

--- a/app/views/categories/show.html.erb
+++ b/app/views/categories/show.html.erb
@@ -1,4 +1,4 @@
-<h2 class="h2 py-8"><%= @category.name%><h2>
+<h1 class="py-8"><%= @category.name%></h1>
 <div class="content-style">
   <%= render partial: "layouts/content_card", collection: @contents, as: "content" %>
 </div>

--- a/app/views/contacts/index.html.erb
+++ b/app/views/contacts/index.html.erb
@@ -1,4 +1,4 @@
-<h2 class="h2 mt-16 mb-12">お問い合わせ<%= " 《確認》" if @contact.submitted == "1" %></h2>
+<h1 class="mt-16 mb-12">お問い合わせ<%= " 《確認》" if @contact.submitted == "1" %></h1>
 <div class="pb-8">
   <%= form_with model: @contact, local: true do |form| %>
     <div class="form-body">

--- a/app/views/contents/_question_card.html.erb
+++ b/app/views/contents/_question_card.html.erb
@@ -27,7 +27,7 @@
 
 
   <!--返信-->
-  <div class="border bg-blue-100 rounded-lg">
+  <div class="border bg-gray-100 rounded-lg">
 
     <% if question.response.present?%> <%# 返信がある場合、返信を表示する%>
       <!-- DEKRIU情報 -->

--- a/app/views/contents/edit.html.erb
+++ b/app/views/contents/edit.html.erb
@@ -1,4 +1,4 @@
-<h1 class="h2 mt-8 mb-2">コンテンツを編集する</h1>
+<h1 class="mt-8 mb-2">コンテンツを編集する</h1>
 <%= link_to ">>コンテンツ詳細へ戻る", content_show_path(@content.id), class:"admin-link"%>
 
 <%= render "form"%>

--- a/app/views/contents/index.html.erb
+++ b/app/views/contents/index.html.erb
@@ -1,4 +1,4 @@
-<h2 class="h2 py-8">コンテンツ一覧</h2>
+<h1 class="py-8">コンテンツ一覧</h1>
 
 <!-- content_card -->
 <div class="content-style">

--- a/app/views/contents/new.html.erb
+++ b/app/views/contents/new.html.erb
@@ -1,4 +1,4 @@
-<h1 class="h2 mt-8 mb-2">コンテンツを新規作成する</h1>
+<h1 class="mt-8 mb-2">コンテンツを新規作成する</h1>
 <%= link_to ">>戻る", mypage_path(current_user), class:"admin-link" %>
 
 <%= render "form"%>

--- a/app/views/contents/newest.html.erb
+++ b/app/views/contents/newest.html.erb
@@ -1,4 +1,4 @@
-<h2 class="h2 py-8">新着情報一覧</h2>
+<h1 class="py-8">新着情報一覧</h1>
 <div class="content-style">
   <%= render partial: "layouts/content_card", collection: @new_contents, as: "content" %>
 </div>

--- a/app/views/contents/popular.html.erb
+++ b/app/views/contents/popular.html.erb
@@ -1,4 +1,4 @@
-<h2 class="h2 py-8">人気情報一覧</h2>
+<h1 class="py-8">人気情報一覧</h1>
 <div class="content-style">
     <%= render partial: "layouts/content_card", collection: @popular_contents, as: "content" %>
 </div>

--- a/app/views/contents/recommend.html.erb
+++ b/app/views/contents/recommend.html.erb
@@ -1,4 +1,4 @@
-<h2 class="h2 py-8">おすすめ情報一覧</h2>
+<h1 class="py-8">おすすめ情報一覧</h1>
 <div class="content-style">
   <%= render partial: "layouts/content_card", collection: @recommend_contents, as: "content" %>
 </div>

--- a/app/views/contents/search.html.erb
+++ b/app/views/contents/search.html.erb
@@ -1,4 +1,4 @@
-<h2 class="h2 py-8">コンテンツ一覧</h2>
+<h1 class="py-8">コンテンツ一覧</h1>
 
 <!-- ワード検索の場合 -->
 <% if params[:q].present? && @search_word.present? %>

--- a/app/views/contents/search.html.erb
+++ b/app/views/contents/search.html.erb
@@ -1,29 +1,33 @@
-<h1 class="py-8">コンテンツ一覧</h1>
+<h1 class="pt-8">コンテンツ一覧</h1>
 
-<!-- ワード検索の場合 -->
-<% if params[:q].present? && @search_word.present? %>
-  <p>「 <%= @search_word %> 」の検索結果<p>
-<% end %>
-
-<!-- タグ検索の場合 -->
-<% if params[:tag_id].present? && @search_word.present? %>
-  <div>
-    <div class="text-dekiru-font text-sm">キーワード</div>
-    <div class="text-dekiru-font">「 <%= @search_word %> 」</div>
-  <div>
-<% end %>
-
-<!-- content_card -->
-<% if @contents.exists? %>
-  <div class="content-style">
-    <%= render partial: "layouts/content_card", collection: @contents, as: "content" %>
+<div class="mt-4 mb-16">
+  
+  <!-- ワード検索の場合 -->
+  <% if params[:q].present? && @search_word.present? %>
+    <p class="p-4">「 <%= @search_word %> 」の検索結果</p>
+  <% end %>
+  
+  <!-- タグ検索の場合 -->
+  <% if params[:tag_id].present? && @search_word.present? %>
+    <div>
+      <div class="text-dekiru-font text-sm">キーワード</div>
+      <div class="text-dekiru-font">「 <%= @search_word %> 」</div>
+    </div>
+  <% end %>
+  
+  <!-- content_card -->
+  <% if @contents.exists? %>
+    <div class="content-style">
+      <%= render partial: "layouts/content_card", collection: @contents, as: "content" %>
+    </div>
+  <% else %>
+    <p>検索結果はありません</p>
+  <% end %>
+  
+  <!-- ページネーション  -->
+  <%= paginate @contents, window: 1 %>
+  <div class="py-4">
+    <%= page_entries_info(@contents)%>
   </div>
-<% else %>
-  <p>検索結果はありません</p>
-<% end %>
 
-<!-- ページネーション  -->
-<%= paginate @contents, window: 1 %>
-<div class="py-4">
-  <%= page_entries_info(@contents)%>
 </div>

--- a/app/views/contents/show.html.erb
+++ b/app/views/contents/show.html.erb
@@ -1,141 +1,141 @@
-<div class="flex p-4">
-  <div class="mr-4">
-    <%= link_to ">>戻る", :back, class:"blue-link" %>
-  </div>
-
-  <% if admin_user? %>
-  <div>
-    <%= link_to ">>編集", edit_content_path, class:"admin-link mr-4" %>
-    <%# TODO: アラートにデザインを当てる %>
-    <%= link_to ">>削除", content_path(@content), data: { confirm: '削除してもよろしいでしょうか？', disable_with: "送信中..."}, method: :delete, class:"admin-link" %>
-  </div>
-  <% end %>
-</div>
-
-<!-- コンテンツ -->
-<div class="mb-8 border bg-gray-100">
-
-  <!-- movie -->
-  <div class="movie">
-    <div class="movie__inner">
-      <%= embed_youtube(@content.movie_url) %>
+<div class="mb-32">
+  <div class="flex p-4">
+    <div class="mr-4">
+      <%= link_to ">>戻る", :back, class:"blue-link" %>
     </div>
+  
+    <% if admin_user? %>
+    <div>
+      <%= link_to ">>編集", edit_content_path, class:"admin-link mr-4" %>
+      <%# TODO: アラートにデザインを当てる %>
+      <%= link_to ">>削除", content_path(@content), data: { confirm: '削除してもよろしいでしょうか？', disable_with: "送信中..."}, method: :delete, class:"admin-link" %>
+    </div>
+    <% end %>
   </div>
-
-  <!-- お気に入り -->
-  <div class="pb-4">
-    <%#= render partial: "favorite_card", collection: @makes, as: "make" %>
-    <div class="mb-4" if="content-<%= @content.id %>">
-      <% if general_user? %>
-      <%# TODO: 条件分岐をリファクタリングすること%>
-        <div class="my-4">
-          <% if @content.favorited_by?(current_user) %>
-            <%= link_to "お気に入り", content_favorites_path(@content), method: :delete, remote: true, class:"favorite-btn" %> <%# お気に入りから外す %>
-          <% else %>
-            <%= link_to "お気に入りする", content_favorites_path(@content), method: :post, remote: true, class:"no-favorite-btn" %><%# お気に入りに追加 %>
-          <% end %>
-        </div>
+  
+  <!-- コンテンツ -->
+  <div class="mb-8 border bg-gray-100">
+  
+    <!-- movie -->
+    <div class="movie">
+      <div class="movie__inner">
+        <%= embed_youtube(@content.movie_url) %>
+      </div>
+    </div>
+  
+    <!-- お気に入り -->
+    <div class="pb-4">
+      <%#= render partial: "favorite_card", collection: @makes, as: "make" %>
+      <div class="mb-4" if="content-<%= @content.id %>">
+        <% if general_user? %>
+        <%# TODO: 条件分岐をリファクタリングすること%>
+          <div class="my-8">
+            <% if @content.favorited_by?(current_user) %>
+              <%= link_to "お気に入り", content_favorites_path(@content), method: :delete, remote: true, class:"favorite-btn" %> <%# お気に入りから外す %>
+            <% else %>
+              <%= link_to "お気に入りする", content_favorites_path(@content), method: :post, remote: true, class:"no-favorite-btn" %><%# お気に入りに追加 %>
+            <% end %>
+          </div>
+        <% end %>
+      </div>
+      <p>お気に入り数:<%= @content.favorites.count %></p>
+    </div>
+  
+    <!-- 説明 -->
+    <div>
+      <p class="text-lg py-4"><%= @content.title %></p>
+      <p class="text-sm p-8"><%= @content. subtitle %></p>
+      <p class="text-md p-8"><%= @content.comment %></p>
+    </div>
+  
+  </div>
+  
+  
+  <!-- タグ -->
+  <div class="p-4 mb-8">
+    <h2 class="mb-4">タグ</h2>
+    <div>
+      <% @content.tag_masters.each do |tag| %>
+        <span class="content-tag-btn">
+          <%= tag.tag_name %>
+        </span>
       <% end %>
     </div>
-    <p>お気に入り数:<%= @content.favorites.count %></p>
   </div>
-
-  <!-- 説明 -->
-  <div>
-    <p class="text-lg py-4"><%= @content.title %></p>
-    <p class="text-sm p-8"><%= @content. subtitle %></p>
-    <p class="text-md p-8"><%= @content.comment %></p>
-  </div>
-
-</div>
-
-
-<!-- タグ -->
-<div class="p-4 mb-8">
-  <h2 class="mb-4">タグ</h2>
-  <div>
-    <% @content.tag_masters.each do |tag| %>
-      <span class="content-tag-btn">
-        <%= tag.tag_name %>
-      </span>
+  
+  <!-- 材料 -->
+  <div class="mb-8 border bg-gray-100">
+    <h2 class="m-4">材料</h2>
+    <!-- 新規作成 -->
+    <% if admin_user? %>
+      <%= link_to ">>追加", new_material_path(params: { content_id: @content.id }), class:"admin-link"%>
     <% end %>
-  </div>
-</div>
-
-<!-- 材料 -->
-<div class="mb-8 border bg-gray-100">
-  <h2 class="m-4">材料</h2>
-  <!-- 新規作成 -->
-  <% if admin_user? %>
-    <%= link_to ">>追加", new_material_path(params: { content_id: @content.id }), class:"admin-link"%>
-  <% end %>
-  <!-- 材料一覧 -->
-  <div class="py-4 px-8 text-left text-lg">
-    <%= render partial: "material_card", collection: @materials, as: "material" %>
-  </div>
-</div>
-
-<!-- 作り方 -->
-<div class="mb-8 border bg-gray-100">
-  <h2 class="m-4">作り方</h2>
-  <% if admin_user? %>
-    <%= link_to ">>追加", new_make_path(params: { content_id: @content.id }), class:"admin-link" %>
-  <% end %>
-  <!-- 作り方一覧 -->
-  <div class="py-4 px-8 text-left text-lg">
-    <%= render partial: "make_card", collection: @makes, as: "make" %>
-  </div>
-</div>
-
-<!-- ポイント -->
-<div class="mb-8 pb-8 border bg-gray-100">
-  <h2 class="py-8">ポイント</h2>
-  <p class="text-left p-8"><%= @content.point %></p>
-</div>
-
-<!-- review -->
-<div class="mb-8 p-4 border bg-gray-100">
-
-  <div class="mb-4 bg-gray-100">
-    <h2 class="pt-8 pm-4">レビュー</h2>
-    <% if general_user? %>
-      <div class="px-4 py-2 text-right">
-        <%= link_to ">>レビューする", new_review_path(params: { content_id: @content.id }), class:"blue-link" %>
-      </div>
-
-    <% end %>
-
-    <!-- レビューカード -->
-    <div class="md:flex justify-start flex-wrap bg-white">
-      <%= render partial: "review_card", collection: @reviews, as: "review" %>
+    <!-- 材料一覧 -->
+    <div class="py-4 px-8 text-left text-lg">
+      <%= render partial: "material_card", collection: @materials, as: "material" %>
     </div>
   </div>
-</div>
-
-
-<!-- 質問と返信 -->
-<div class="py-4 my-4 bg-dekiru-base">
-
-  <!-- 質問フォーム -->
-  <h2 class="mt-8 mb-4">質問</h2>
-  <%= render partial: "question_card", collection: @questions, as: "question" %>
-  <%# TODO: jqueryでアコーディオンを検討(長くなるので) %>
-
-  <!-- 質問 -->
-  <h2 class="py-4">質問する</h2>
-  <!-- 質問フォーム -->
-  <div>
-  <% if user_signed_in? %>
-    <% if current_user.general? %>
-      <%= render "question_form" %>
-    <% else %>
-      <p>管理者は質問できません。</p>
+  
+  <!-- 作り方 -->
+  <div class="mb-8 border bg-gray-100">
+    <h2 class="m-4">作り方</h2>
+    <% if admin_user? %>
+      <%= link_to ">>追加", new_make_path(params: { content_id: @content.id }), class:"admin-link" %>
     <% end %>
-  <% else %>
-    <p>ログインすると、質問ができます</p>
-  <% end %>
+    <!-- 作り方一覧 -->
+    <div class="py-4 px-8 text-left text-lg">
+      <%= render partial: "make_card", collection: @makes, as: "make" %>
+    </div>
   </div>
-
+  
+  <!-- ポイント -->
+  <div class="mb-8 pb-8 border bg-gray-100">
+    <h2 class="py-8">ポイント</h2>
+    <p class="text-left p-8"><%= @content.point %></p>
+  </div>
+  
+  <!-- review -->
+  <div class="mb-8 p-4 border bg-gray-100">
+  
+    <div class="mb-4 bg-gray-100">
+      <h2 class="pt-8 pm-4">レビュー</h2>
+      <% if general_user? %>
+        <div class="px-4 py-2 text-right">
+          <%= link_to ">>レビューする", new_review_path(params: { content_id: @content.id }), class:"blue-link" %>
+        </div>
+  
+      <% end %>
+  
+      <!-- レビューカード -->
+      <div class="md:flex justify-start flex-wrap bg-white">
+        <%= render partial: "review_card", collection: @reviews, as: "review" %>
+      </div>
+    </div>
+  </div>
+  
+  
+  <!-- 質問と返信 -->
+  <div class="py-4 my-4 bg-dekiru-base">
+  
+    <!-- 質問フォーム -->
+    <h2 class="mt-8 mb-4">質問</h2>
+    <%= render partial: "question_card", collection: @questions, as: "question" %>
+    <%# TODO: jqueryでアコーディオンを検討(長くなるので) %>
+  
+    <!-- 質問 -->
+    <h2 class="py-4">質問する</h2>
+    <!-- 質問フォーム -->
+    <div>
+    <% if user_signed_in? %>
+      <% if current_user.general? %>
+        <%= render "question_form" %>
+      <% else %>
+        <p>管理者は質問できません。</p>
+      <% end %>
+    <% else %>
+      <p>ログインすると、質問ができます</p>
+    <% end %>
+    </div>
+  
+  </div>
 </div>
-
-

--- a/app/views/contents/show.html.erb
+++ b/app/views/contents/show.html.erb
@@ -52,7 +52,7 @@
 
 <!-- タグ -->
 <div class="p-4 mb-8">
-  <h2 class="h2 mb-4">タグ</h2>
+  <h2 class="mb-4">タグ</h2>
   <div>
     <% @content.tag_masters.each do |tag| %>
       <span class="content-tag-btn">
@@ -64,7 +64,7 @@
 
 <!-- 材料 -->
 <div class="mb-8 border bg-gray-100">
-  <h2 class="h2 m-4">材料</h2>
+  <h2 class="m-4">材料</h2>
   <!-- 新規作成 -->
   <% if admin_user? %>
     <%= link_to ">>追加", new_material_path(params: { content_id: @content.id }), class:"admin-link"%>
@@ -77,7 +77,7 @@
 
 <!-- 作り方 -->
 <div class="mb-8 border bg-gray-100">
-  <h2 class="h2 m-4">作り方</h2>
+  <h2 class="m-4">作り方</h2>
   <% if admin_user? %>
     <%= link_to ">>追加", new_make_path(params: { content_id: @content.id }), class:"admin-link" %>
   <% end %>
@@ -89,7 +89,7 @@
 
 <!-- ポイント -->
 <div class="mb-8 pb-8 border bg-gray-100">
-  <h2 class="h2 py-8">ポイント</h2>
+  <h2 class="py-8">ポイント</h2>
   <p class="text-left p-8"><%= @content.point %></p>
 </div>
 
@@ -97,7 +97,7 @@
 <div class="mb-8 p-4 border bg-gray-100">
 
   <div class="mb-4 bg-gray-100">
-    <h2 class="h2 pt-8 pm-4">レビュー</h2>
+    <h2 class="pt-8 pm-4">レビュー</h2>
     <% if general_user? %>
       <div class="px-4 py-2 text-right">
         <%= link_to ">>レビューする", new_review_path(params: { content_id: @content.id }), class:"blue-link" %>
@@ -117,12 +117,12 @@
 <div class="py-4 my-4 bg-dekiru-base">
 
   <!-- 質問フォーム -->
-  <h2 class="h2 mt-8 mb-4">質問</h2>
+  <h2 class="mt-8 mb-4">質問</h2>
   <%= render partial: "question_card", collection: @questions, as: "question" %>
   <%# TODO: jqueryでアコーディオンを検討(長くなるので) %>
 
   <!-- 質問 -->
-  <h2 class="h2 py-4">質問する</h2>
+  <h2 class="py-4">質問する</h2>
   <!-- 質問フォーム -->
   <div>
   <% if user_signed_in? %>

--- a/app/views/homes/index.html.erb
+++ b/app/views/homes/index.html.erb
@@ -9,7 +9,7 @@
 <div class="border p-4 my-8 bg-gray-100">
   <div class="flex justify-center">
     <div>
-      <h2 class="h2">人気情報</h2>
+      <h2>人気情報</h2>
       <%= link_to ">>全て見る", popular_contents_path, class:"blue-link" %>
     </div>
   </div>
@@ -23,7 +23,7 @@
 <div class="border p-4 my-8 bg-gray-100">
     <div class="flex justify-center">
       <div>
-        <h2 class="h2">おすすめ情報</h2>
+        <h2>おすすめ情報</h2>
         <%= link_to ">>全て見る", recommend_contents_path, class:"blue-link" %>
       </div>
     </div>
@@ -36,7 +36,7 @@
 <div class="border p-4 my-8 bg-gray-100">
   <div class="flex justify-center">
     <div>
-      <h2 class="h2">新着情報</h2>
+      <h2>新着情報</h2>
       <%= link_to ">>全て見る", newest_contents_path, class:"blue-link" %>
     </div>
   </div>
@@ -48,7 +48,7 @@
 <div class="border p-4 my-8 bg-gray-100">
   <div class="flex justify-center">
     <div>
-      <h2 class="h2">カテゴリー一覧</h2>
+      <h2>カテゴリー一覧</h2>
       <%= link_to ">>全て見る", categories_path, class:"blue-link" %>
     </div>
   </div>
@@ -61,7 +61,7 @@
 <br/>
 
 <div class="border p-4 mb-8 bg-gray-100">
-  <h2 class="h2">キーワード</h2>
+  <h2>キーワード</h2>
   <%#= link_to ">>全て見る", root_path %><%# TODO: 数が多くなった場合実装する%>
   <div class="flex justify-start flex-wrap my-2"> 
     <%= render partial: "layouts/content_tag", collection: @content_tags, as: "tag" %>

--- a/app/views/homes/index.html.erb
+++ b/app/views/homes/index.html.erb
@@ -9,7 +9,7 @@
 <div class="border p-4 my-8 bg-gray-100">
   <div class="flex justify-center">
     <div>
-      <h2>人気情報</h2>
+      <h2 class="pt-4">人気情報</h2>
       <%= link_to ">>全て見る", popular_contents_path, class:"blue-link" %>
     </div>
   </div>
@@ -23,7 +23,7 @@
 <div class="border p-4 my-8 bg-gray-100">
     <div class="flex justify-center">
       <div>
-        <h2>おすすめ情報</h2>
+        <h2 class="pt-4">おすすめ情報</h2>
         <%= link_to ">>全て見る", recommend_contents_path, class:"blue-link" %>
       </div>
     </div>
@@ -36,7 +36,7 @@
 <div class="border p-4 my-8 bg-gray-100">
   <div class="flex justify-center">
     <div>
-      <h2>新着情報</h2>
+      <h2 class="pt-4">新着情報</h2>
       <%= link_to ">>全て見る", newest_contents_path, class:"blue-link" %>
     </div>
   </div>
@@ -48,7 +48,7 @@
 <div class="border p-4 my-8 bg-gray-100">
   <div class="flex justify-center">
     <div>
-      <h2>カテゴリー一覧</h2>
+      <h2 class="pt-4">カテゴリー一覧</h2>
       <%= link_to ">>全て見る", categories_path, class:"blue-link" %>
     </div>
   </div>
@@ -61,7 +61,7 @@
 <br/>
 
 <div class="border p-4 mb-8 bg-gray-100">
-  <h2>キーワード</h2>
+  <h2 class="pt-4">キーワード</h2>
   <%#= link_to ">>全て見る", root_path %><%# TODO: 数が多くなった場合実装する%>
   <div class="flex justify-start flex-wrap my-2"> 
     <%= render partial: "layouts/content_tag", collection: @content_tags, as: "tag" %>

--- a/app/views/layouts/_content_tag.html.erb
+++ b/app/views/layouts/_content_tag.html.erb
@@ -1,6 +1,6 @@
 
 <%= link_to search_contents_path(tag_id: tag.id) do %>
-  <div class="flex">
+  <div class="flex my-4">
     <span class="content-tag-btn"><%= tag[:tag_name] %></span>
     <% if admin_user? %>
       <%# TODO: home#indexの場合、非表示にしたい。%>

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -13,11 +13,11 @@
 
     <!-- 各種リンク -->
     <ul class="p-4 text-dekiru-font md:w-1/2 md:text-right">
-      <li class="mb-8 md:mb-4"><%= link_to "トップ", root_path %></li>
-      <li class="mb-8 md:mb-4"><%= link_to "カテゴリー一覧", categories_path %></li>
+      <li class="mb-8 md:mb-4"><%= link_to "トップ", root_path, class:"hover:text-dekiru-blue" %></li>
+      <li class="mb-8 md:mb-4"><%= link_to "カテゴリー一覧", categories_path, class:"hover:text-dekiru-blue" %></li>
       <% if user_signed_in? %>
-        <li class="mb-8 md:mb-4"><%= link_to "マイページ", mypage_path(current_user) %></li>
-        <li class="mb-8"><%= link_to "お問い合わせ", contacts_path %></li>
+        <li class="mb-8 md:mb-4"><%= link_to "マイページ", mypage_path(current_user), class:"hover:text-dekiru-blue" %></li>
+        <li class="mb-8"><%= link_to "お問い合わせ", contacts_path, class:"hover:text-dekiru-blue" %></li>
       <% end %>
     </ul>
 

--- a/app/views/layouts/_search_form.html.erb
+++ b/app/views/layouts/_search_form.html.erb
@@ -1,8 +1,8 @@
 <!-- 検索フォーム -->
 <div>
   <%= search_form_for @q, url: search_contents_path do |f| %>
-    <%= f.search_field :title_or_subtitle_or_comment_or_tag_masters_tag_name_cont, placeholder:"キーワードを入力", class:"text-filed bg-gray-200 rounded-full p-2" %>
+    <%= f.search_field :title_or_subtitle_or_comment_or_tag_masters_tag_name_cont, placeholder:"キーワードを入力", class:"text-filed bg-gray-200 rounded-full p-2 focus:outline-none" %>
     <%# これをアイコンにする%>
-    <%= f.submit class: "bg-white"%>
+    <%= f.submit class: "bg-dekiru-base"%>
   <% end %>
 </div>

--- a/app/views/makes/edit.html.erb
+++ b/app/views/makes/edit.html.erb
@@ -1,3 +1,3 @@
-<h1 class="h2 my-8">作り方を編集</h1>
+<h1 class="my-8">作り方を編集</h1>
 
 <%= render "form"%>

--- a/app/views/makes/new.html.erb
+++ b/app/views/makes/new.html.erb
@@ -1,3 +1,3 @@
-<h1 class="h2 my-8">作り方を追加</h1>
+<h1 class="my-8">作り方を追加</h1>
 
 <%= render "form"%>

--- a/app/views/materials/edit.html.erb
+++ b/app/views/materials/edit.html.erb
@@ -1,3 +1,3 @@
-<h1 class="h2 my-8">材料を編集</h1>
+<h1 class="my-8">材料を編集</h1>
 
 <%= render "form"%>

--- a/app/views/materials/new.html.erb
+++ b/app/views/materials/new.html.erb
@@ -1,3 +1,3 @@
-<h1 class="h2 my-8">材料を追加</h1>
+<h1 class="my-8">材料を追加</h1>
 
 <%= render "form"%>

--- a/app/views/responses/edit.html.erb
+++ b/app/views/responses/edit.html.erb
@@ -1,3 +1,3 @@
-<h1 class="h2 my-8">返信を編集する</h1>
+<h1 class="my-8">返信を編集する</h1>
 
 <%= render "form" %>

--- a/app/views/responses/new.html.erb
+++ b/app/views/responses/new.html.erb
@@ -1,3 +1,3 @@
-<h1 class="h2 my-8">返信する</h1>
+<h1 class="my-8">返信する</h1>
 
 <%= render "form" %>

--- a/app/views/reviews/new.html.erb
+++ b/app/views/reviews/new.html.erb
@@ -1,4 +1,4 @@
-<h1 class="h2 my-8">レビュー登録</h1>
+<h1 class="my-8">レビュー登録</h1>
 
 <%= form_with model: @review, local: true do |f| %>
   <div class="form-body">

--- a/app/views/tag_masters/edit.html.erb
+++ b/app/views/tag_masters/edit.html.erb
@@ -1,3 +1,3 @@
-<h1 class="h2 my-8">タグを編集</h1>
+<h1 class="my-8">タグを編集</h1>
 
 <%= render "form"%>

--- a/app/views/tag_masters/new.html.erb
+++ b/app/views/tag_masters/new.html.erb
@@ -1,3 +1,3 @@
-<h1 class="h2 my-8">タグを追加</h1>
+<h1 class="my-8">タグを追加</h1>
 
 <%= render "form"%>

--- a/app/views/users/confirmations/new.html.erb
+++ b/app/views/users/confirmations/new.html.erb
@@ -1,4 +1,4 @@
-<h2 class="h2 py-8">Resend confirmation instructions</h2>
+<h1 class="py-8">Resend confirmation instructions</h1>
 
 <%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f| %>
   <%= render "users/shared/error_messages", resource: resource %>

--- a/app/views/users/favorite.html.erb
+++ b/app/views/users/favorite.html.erb
@@ -1,4 +1,4 @@
-<h2 class="h2 py-8">お気に入り一覧</h2>
+<h1 class="py-8">お気に入り一覧</h1>
 
 <% if  @favorite_contents.exists? %>
   <div class="content-style">

--- a/app/views/users/passwords/edit.html.erb
+++ b/app/views/users/passwords/edit.html.erb
@@ -1,4 +1,4 @@
-<h2 class="h2 py-8">Change your password</h2>
+<h1 class="py-8">Change your password</h1>
 
 <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
   <%= render "users/shared/error_messages", resource: resource %>

--- a/app/views/users/passwords/new.html.erb
+++ b/app/views/users/passwords/new.html.erb
@@ -1,4 +1,4 @@
-<h2 class="h2 py-8">パスワード再設定</h2>
+<h1 class="py-8">パスワード再設定</h1>
 
 <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
   <%= render "users/shared/error_messages", resource: resource %>

--- a/app/views/users/registrations/edit.html.erb
+++ b/app/views/users/registrations/edit.html.erb
@@ -1,7 +1,7 @@
 <%# TODO: ルーディングを調整すること%>
 <div class="p-4 mb-20">
 
-<h2 class="h2 pt-8 pb-4">アカウント編集</h2>
+<h1 class="pt-8 pb-4">アカウント編集</h1>
 <%= link_to ">>マイページへ戻る", mypage_path(current_user), class:"blue-link"%>
 
 <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -1,4 +1,4 @@
-<h2 class="h2 py-8">アカウント新規作成</h2>
+<h1 class="py-8">アカウント新規作成</h1>
 
 <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
   <div class="form-body">

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -1,36 +1,41 @@
-<h1 class="my-8">ログイン</h1>
+<h1 class="mt-16 mb-8">ログイン</h1>
 
 <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
-<div class="form-body py-8">
+<div class="form-body py-16 px-8 border shadow-lg mb-24 bg-dekiru-base">
   
   <div class="field">
     <h2 class="form-title">メールアドレス<span class="required_content">必須</span></h2>
-    <%= f.email_field :email, autofocus: true, autocomplete: "email",required: true, class:"login-field" %>
+    <%= f.email_field :email, autofocus: true, autocomplete: "email",required: true, class:"text-field" %>
   </div>
 
   <div class="field">
     <h2 class="form-title">パスワード<span class="required_content">必須</span></h2>
-    <%= f.password_field :password, autocomplete: "current-password",required: true, class:"login-field" %>
+    <%= f.password_field :password, autocomplete: "current-password",required: true, class:"text-field" %>
   </div>
 
   <% if devise_mapping.rememberable? %>
-    <div class="field my-4">
+    <div class="field my-8 mb-4">
       <%= f.check_box :remember_me %>
       <%= f.label :remember_me %>
     </div>
   <% end %>
 
+  <!-- ログイン-->
   <div class="actions">
     <%= f.submit "ログイン", class:"submit-btn" %>
-    <%# TODO: 共通化すること %>
-    <%#= f.submit  t(".sign_in") %>
   </div>
-</div>
 
+  <!-- 新規作成 -->
+  <div>
+    <%= render "users/shared/links" %>
+  </div>
+  
+  <!-- ゲストログイン(後日削除予定)-->
+  <div class="mt-10">
+    <%= link_to "ゲストログイン（閲覧用）", users_guest_sign_in_path, method: :post, class: "blue-btn"%>
+  </div>
+
+</div>
 <% end %>
 
-<%= render "users/shared/links" %>
 
-<div class="my-4">
-  <%= link_to "ゲストログイン（閲覧用）", users_guest_sign_in_path, method: :post, class: "blue-btn"%>
-</div>

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -1,4 +1,4 @@
-<h2 class="h2 my-8">ログイン</h2>
+<h1 class="my-8">ログイン</h1>
 
 <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
 <div class="form-body py-8">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -13,24 +13,19 @@
   </div>
 
   <!-- お気に入り一覧-->
-  <div class="my-8 text-center">
-    <%= link_to favorite_contents_path, class:"blue-link border border-blue-500 w-40 py-2 px-4 hover:bg-dekiru-blue hover:text-white" do %>
-      <button class="w-32">お気に入り一覧</button>
-    <% end %>
+  <div class="my-8">
+    <%= link_to "お気に入り一覧", favorite_contents_path, class:"blue-btn" %>
   </div>
 
   <!-- アカウント編集-->
-  <div class="my-8 text-center">
-    <%= link_to edit_user_registration_path(current_user), class:"blue-link border border-blue-500  py-2 px-4 hover:bg-dekiru-blue hover:text-white" do %>
-      <button class="w-32">アカウント編集</button>
-    <% end %>
+  <div class="my-8">
+    <%= link_to "アカウント編集", edit_user_registration_path(current_user), class:"blue-btn"%>
   </div>
 
+
   <!-- ログアウト-->
-  <div class="my-8 text-center">
-    <%= link_to destroy_user_session_path, method: :delete, data: { confirm: "ログアウトしますか？", disable_with: "送信中..." }, class: "red-link w-40 border border-red-500 py-2 px-4 w-32 hover:bg-red-500 hover:text-white" do%>
-      <button class="w-32">ログアウト</button>
-    <% end %>
+  <div class="my-8 m-auto">
+    <%= link_to "ログアウト", destroy_user_session_path, method: :delete, data: { confirm: "ログアウトしますか？", disable_with: "送信中..." }, class: "red-btn"%>
   </div>
 
   <!-- 管理者専用-->
@@ -38,24 +33,40 @@
     <div class="text-left p-8">
       <h2 class="text-pink-500">管理者専用</h2>
       
-      <h2 class="py-8">1.タグ一覧</h2>
-      <div>
-        <%= link_to ">>追加", new_tag_master_path, class:"admin-link" %>
-        <%= render partial: "layouts/content_tag", collection: @content_tags, as: "tag" %>
-      </div>
 
-      <h2 class="py-8">2.カテゴリー作成</h2>
-      <div>
-        <%= link_to ">>追加", new_category_path, class:"admin-link" %>
-      </div>
 
-      <div>
-        <h2 class="py-8">3.コンテンツ作成</h2>
+      <!-- コンテンツ -->
+      <div class="my-8">
+        <h2>1.コンテンツ作成</h2>
         <!-- 新規作成リンク(管理者のみ) -->
         <div><%= link_to ">>新規作成",new_content_path, class:"admin-link" %></div>
       </div>
 
+      <!-- カテゴリー -->
+      <div class="my-8">
+
+      <h2>2.カテゴリー作成</h2>
+      <div>
+        <%= link_to ">>追加", new_category_path, class:"admin-link" %>
+      </div>
+      </div>
+
+
+
+      <!-- タグ -->
+      <div class="my-8">
+        <h2>3.タグ一覧</h2>
+        <div class="my-4">
+          <%= link_to ">>追加", new_tag_master_path, class:"admin-link" %>
+          <%= render partial: "layouts/content_tag", collection: @content_tags, as: "tag" %>
+        </div>
+      </div>
+
+
+
     </div>
+
+
   <% end %>
 
   </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,6 +1,6 @@
 <div class="text-center pt-16 pb-32">
   <!-- タイトル-->
-  <h2 class="h2 py-8">MyPage</h2>
+  <h1 class="py-8">MyPage</h1>
 
   <!-- 写真 + 名前 -->
   <div class="py-8">
@@ -38,19 +38,19 @@
     <div class="text-left p-8">
       <h2 class="text-pink-500">管理者専用</h2>
       
-      <h2 class="h2 py-8">1.タグ一覧</h2>
+      <h2 class="py-8">1.タグ一覧</h2>
       <div>
         <%= link_to ">>追加", new_tag_master_path, class:"admin-link" %>
         <%= render partial: "layouts/content_tag", collection: @content_tags, as: "tag" %>
       </div>
 
-      <h2 class="h2 py-8">2.カテゴリー作成</h2>
+      <h2 class="py-8">2.カテゴリー作成</h2>
       <div>
         <%= link_to ">>追加", new_category_path, class:"admin-link" %>
       </div>
 
       <div>
-        <h2 class="h2 py-8">3.コンテンツ作成</h2>
+        <h2 class="py-8">3.コンテンツ作成</h2>
         <!-- 新規作成リンク(管理者のみ) -->
         <div><%= link_to ">>新規作成",new_content_path, class:"admin-link" %></div>
       </div>

--- a/app/views/users/unlocks/new.html.erb
+++ b/app/views/users/unlocks/new.html.erb
@@ -1,4 +1,4 @@
-<h2 class="h2 py-8">Resend unlock instructions</h2>
+<h1 class="py-8">Resend unlock instructions</h1>
 
 <%= form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f| %>
   <%= render "users/shared/error_messages", resource: resource %>


### PR DESCRIPTION
## 実装の目的と概要
- ボタンのスタイルの共通化し、リファクタリング
- tailwindcssの使い方を実践

## 実装内容(技術的な点を記載)
- [x] ボタンのスタイルの共通化
- [x] ベーススタイルを実装 (`@layer`)

## スクリーンショット（画面レイアウトを変更した場合）
<img width="834" alt="スクリーンショット 2021-06-09 18 47 58" src="https://user-images.githubusercontent.com/64491435/121332913-427eb200-c953-11eb-809b-4310813688da.png">
<img width="834" alt="スクリーンショット 2021-06-09 18 47 45" src="https://user-images.githubusercontent.com/64491435/121332929-48749300-c953-11eb-8789-3157ba4fc93f.png">


## チェックリスト

- [x] ローカル環境での動作確認をしたか（影響し得る範囲も含めて）
- [x] rubocopを実行して警告が出力されていないか
- [x] GitHub で ファイル差分（Files changed）を確認し、内容が合っているか。不要なファイルに差分がでていないか
- [x] テストでエラーが発生していないか

## 備考（実装していないことなど）
