### PR TITLE
[レイアウト]写真選択のレイアウトを実装

### DIFF
--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -142,3 +142,23 @@ iframe {
   width: 100%;
   height: 100%;
 }
+
+//************ file_field **************//
+
+.image_input_btn{
+  // display: block;
+  // background-color: #228B22;
+  width: 180px;
+  height: 30px;
+  // margin-top: 10px;
+  // margin-left: 10px;
+  border-radius: 5px;
+  padding-top: 2px;
+  // color: white;
+  text-decoration: none;
+  // text-align: center;
+}
+
+.file_field {
+  @apply block text-white border-dekiru-light_blue bg-dekiru-blue  hover:bg-dekiru-light_blue hover:text-white cursor-pointer text-center
+}

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -51,6 +51,9 @@
   @apply text-white bg-dekiru-keyword hover:bg-green-400 border-0 m-1 py-2 px-6 focus:outline-none text-lg
 }
 
+.file_field {
+  @apply block text-white  pt-1 w-48 h-8 border-dekiru-light_blue bg-dekiru-blue  hover:bg-dekiru-light_blue hover:text-white cursor-pointer text-center no-underline rounded-sm shadow-2xl
+}
 
 //************リンク**************//
 
@@ -143,22 +146,3 @@ iframe {
   height: 100%;
 }
 
-//************ file_field **************//
-
-.image_input_btn{
-  // display: block;
-  // background-color: #228B22;
-  width: 180px;
-  height: 30px;
-  // margin-top: 10px;
-  // margin-left: 10px;
-  border-radius: 5px;
-  padding-top: 2px;
-  // color: white;
-  text-decoration: none;
-  // text-align: center;
-}
-
-.file_field {
-  @apply block text-white border-dekiru-light_blue bg-dekiru-blue  hover:bg-dekiru-light_blue hover:text-white cursor-pointer text-center
-}

--- a/app/views/reviews/new.html.erb
+++ b/app/views/reviews/new.html.erb
@@ -5,14 +5,15 @@
     <%= render 'layouts/error_messages', model: f.object %>
   
     <%= f.hidden_field :content_id, value: @content_id %>
-
-    <div>
-      <div class="form-title">写真<span class="required_content">必須</span></div>
-      <div class="mx-auto max-w-4xl">
-        <%= f.file_field :image, accept: "image/png,image/jpeg", class:"block"%>
-      </div>
-    </div>
   
+     <div class="field">
+        <div class="form-title">写真<span class="required_content">必須</span></div>
+        <div class="max-w-4xl mx-auto">
+          <%= f.label :image, class: "image_input_btn file_field" %>
+          <%= f.file_field :image, accept: "image/png,image/jpeg", class: "hidden" %>
+        </div>
+      </div>
+
     <div>
       <div class="form-title">レビュー<span class="required_content">必須</span></div>
       <%= f.text_area :comment, placeholder: "レビュー内容(500文字以内)",required: true, class:"text-area" %>

--- a/app/views/reviews/new.html.erb
+++ b/app/views/reviews/new.html.erb
@@ -9,7 +9,7 @@
      <div class="field">
         <div class="form-title">写真<span class="required_content">必須</span></div>
         <div class="max-w-4xl mx-auto">
-          <%= f.label :image, class: "image_input_btn file_field" %>
+          <%= f.label :image, class: "file_field" %>
           <%= f.file_field :image, accept: "image/png,image/jpeg", class: "hidden" %>
         </div>
       </div>

--- a/app/views/reviews/new.html.erb
+++ b/app/views/reviews/new.html.erb
@@ -6,11 +6,12 @@
   
     <%= f.hidden_field :content_id, value: @content_id %>
   
-     <div class="field">
-        <div class="form-title">写真<span class="required_content">必須</span></div>
+      <div class="field pb-4">
+        <h2 class="form-title">写真<span class="required_content">必須</span></h2>
         <div class="max-w-4xl mx-auto">
-          <%= f.label :image, class: "file_field" %>
-          <%= f.file_field :image, accept: "image/png,image/jpeg", class: "hidden" %>
+          <%#= image_tag @user.thumbnail.url, id: :img_prev ,class:"my-4 border-4 border-gray-300"%>
+          <label class="file_field" for="review_image">選択する</label>
+          <%= f.file_field :thumbnail, id: "review_image", accept: "image/png,image/jpeg", class: "hidden" %>
         </div>
       </div>
 
@@ -18,10 +19,10 @@
       <div class="form-title">レビュー<span class="required_content">必須</span></div>
       <%= f.text_area :comment, placeholder: "レビュー内容(500文字以内)",required: true, class:"text-area" %>
     </div>
-    
+
     <div>
       <%= f.submit "確定する", data: { confirm: '確定します。よろしいでしょうか？', disable_with: "送信中..."}, class:"submit-btn" %>
     </div>
-  
+
   </div>
 <% end %>

--- a/app/views/users/registrations/edit.html.erb
+++ b/app/views/users/registrations/edit.html.erb
@@ -22,7 +22,7 @@
       <div class="field">
         <div class="form-title">サムネイル画像</div>
         <div class="max-w-4xl mx-auto">
-          <%= f.label :thumbnail, class: "image_input_btn file_field" %>
+          <%= f.label :thumbnail, class: "file_field" %>
           <%= f.file_field :thumbnail, accept: "image/png,image/jpeg", class: "hidden" %>
         </div>
       </div>

--- a/app/views/users/registrations/edit.html.erb
+++ b/app/views/users/registrations/edit.html.erb
@@ -19,11 +19,12 @@
         <%= f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "例：sample@gmail.com",required: true, class: "text-field" %>
       </div>
 
-      <div class="field">
-        <div class="form-title">サムネイル画像</div>
+      <div class="field pb-4">
+        <h2 class="form-title">サムネイル画像</h2>
         <div class="max-w-4xl mx-auto">
-          <%= f.label :thumbnail, class: "file_field" %>
-          <%= f.file_field :thumbnail, accept: "image/png,image/jpeg", class: "hidden" %>
+          <%#= image_tag @user.thumbnail.url, id: :img_prev ,class:"my-4 border-4 border-gray-300"%>
+          <label class="file_field" for="user_thumbnail">選択する</label>
+          <%= f.file_field :thumbnail, id: "user_thumbnail", accept: "image/png,image/jpeg", class: "hidden" %>
         </div>
       </div>
 
@@ -63,4 +64,3 @@
 <%# アカウント削除ボタンを導入する場合は以下をコメントアウト %>
 <%#= button_to "このアカウント削除", registration_path(resource_name), data: { confirm: "アカウントを削除しますか？" , disable_with: "送信中..."}, method: :delete %>
 <%#= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete %>
-

--- a/app/views/users/registrations/edit.html.erb
+++ b/app/views/users/registrations/edit.html.erb
@@ -20,8 +20,11 @@
       </div>
 
       <div class="field">
-        <%= f.label :thumbnail, class: "form-title" %>
-        <%= f.file_field :thumbnail, accept: "image/png,image/jpeg", class: "text-field" %>
+        <div class="form-title">サムネイル画像</div>
+        <div class="max-w-4xl mx-auto">
+          <%= f.label :thumbnail, class: "image_input_btn file_field" %>
+          <%= f.file_field :thumbnail, accept: "image/png,image/jpeg", class: "hidden" %>
+        </div>
       </div>
 
       <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -22,7 +22,6 @@
     <%= link_to "アカウント編集", edit_user_registration_path(current_user), class:"blue-btn"%>
   </div>
 
-
   <!-- ログアウト-->
   <div class="my-8 m-auto">
     <%= link_to "ログアウト", destroy_user_session_path, method: :delete, data: { confirm: "ログアウトしますか？", disable_with: "送信中..." }, class: "red-btn"%>
@@ -32,8 +31,6 @@
   <% if admin_user? %>
     <div class="text-left p-8">
       <h2 class="text-pink-500">管理者専用</h2>
-      
-
 
       <!-- コンテンツ -->
       <div class="my-8">
@@ -51,8 +48,6 @@
       </div>
       </div>
 
-
-
       <!-- タグ -->
       <div class="my-8">
         <h2>3.タグ一覧</h2>
@@ -62,10 +57,7 @@
         </div>
       </div>
 
-
-
     </div>
-
 
   <% end %>
 


### PR DESCRIPTION
## 実装の目的と概要
- 写真選択のレイアウトを実装
## 実装内容(技術的な点を記載) 
- [x] 写真選択のレイアウトを実装

## スクリーンショット（画面レイアウトを変更した場合）
<img width="834" alt="スクリーンショット 2021-06-10 0 49 02" src="https://user-images.githubusercontent.com/64491435/121387522-b2a62b80-c985-11eb-8828-3339578e8ea8.png">
<img width="834" alt="スクリーンショット 2021-06-10 0 48 35" src="https://user-images.githubusercontent.com/64491435/121387535-b46fef00-c985-11eb-9939-4f09ce0b2ef5.png">


## 参考資料
- [[Rails][file_field]画像のアップロードのボタンデザインを変更する](https://qiita.com/Yukina_28/items/4a8332354f6cb7c7a6f6)
## チェックリスト

- [x] ローカル環境での動作確認をしたか（影響し得る範囲も含めて）
- [x] rubocopを実行して警告が出力されていないか
- [x] GitHub で ファイル差分（Files changed）を確認し、内容が合っているか。不要なファイルに差分がでていないか
- [x] テストでエラーが発生していないか
