### PR TITLE
[レイアウト]ボタン幅の調整

### DIFF
--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -29,7 +29,7 @@
 }
 
 .submit-btn {
-  @apply base_btn bg-green-500 hover:bg-green-700 
+  @apply base_btn bg-green-500 hover:bg-green-700
 }
 
 // お気に入りボタン
@@ -65,11 +65,11 @@
 }
 
 .red-link {
-  @apply text-red-700 text-sm
+  @apply text-red-700 hover:text-red-300 text-sm
 }
 
 .admin-link {
-  @apply text-pink-500 text-sm
+  @apply text-pink-500 hover:text-pink-300 text-sm
 }
 
 //************カード**************//

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -69,7 +69,7 @@
 }
 
 .admin-link {
-  @apply text-pink-500 hover:text-pink-300 text-sm
+  @apply text-dekiru-admin hover:text-pink-300 text-sm
 }
 
 //************カード**************//

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -46,9 +46,13 @@
   @apply text-white bg-dekiru-blue border-0 m-1 py-2 px-6 focus:outline-none text-lg
 }
 
-//コンテンツタグ
+//コンテンツタグ(リンクあり)
 .content-tag-btn {
   @apply text-white bg-dekiru-keyword hover:bg-green-400 border-0 m-1 py-2 px-6 focus:outline-none text-lg
+}
+//コンテンツタグ(リンクなし)
+.content-tag-style {
+  @apply text-white bg-dekiru-keyword border-0 m-1 py-2 px-6 focus:outline-none text-lg
 }
 
 .file_field {
@@ -56,18 +60,14 @@
 }
 
 //************リンク**************//
-
-//mailCRUDリンク
 .blue-link {
   @apply text-dekiru-blue text-sm hover:text-dekiru-light_blue
 }
 
-//削除リンク
 .red-link {
   @apply text-red-700 text-sm
 }
 
-//管理者CRUDリンク
 .admin-link {
   @apply text-pink-500 text-sm
 }
@@ -130,7 +130,6 @@
 .supplement_comment {
   @apply my-2 text-sm text-left block max-w-4xl mx-auto opacity-70
 }
-
 
 //************ movie **************//
 .movie__inner {

--- a/app/javascript/stylesheets/tailwind.config.js
+++ b/app/javascript/stylesheets/tailwind.config.js
@@ -20,6 +20,8 @@ module.exports = {
           light_blue: '#72FFFF',
           font: '#000000',
           keyword: '#595959',
+          // gray: bg-gray-100,
+          admin: '#FA198B',
         }
       },
     },

--- a/app/views/contents/show.html.erb
+++ b/app/views/contents/show.html.erb
@@ -56,7 +56,7 @@
     <h2 class="mb-4">タグ</h2>
     <div>
       <% @content.tag_masters.each do |tag| %>
-        <span class="content-tag-btn">
+        <span class="content-tag-style">
           <%= tag.tag_name %>
         </span>
       <% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -12,22 +12,26 @@
     <p class="text-lg"><%= @user.name %></p>
   </div>
 
+<div>
   <!-- お気に入り一覧-->
-  <div class="my-8">
-    <%= link_to "お気に入り一覧", favorite_contents_path, class:"blue-btn" %>
-  </div>
+  <span class="block m-auto max-w-sm">
+    <%= link_to "お気に入り一覧", favorite_contents_path, class:"blue-btn w-2/3 block m-auto" %>
+  </span>
 
   <!-- アカウント編集-->
-  <div class="my-8">
-    <%= link_to "アカウント編集", edit_user_registration_path(current_user), class:"blue-btn"%>
-  </div>
+  <span class="block w-full m-auto max-w-sm">
+    <%= link_to "アカウント編集", edit_user_registration_path(current_user), class:"blue-btn w-2/3 m-auto block"%>
+  </span>
 
   <!-- ログアウト-->
-  <div class="my-8 m-auto">
-    <%= link_to "ログアウト", destroy_user_session_path, method: :delete, data: { confirm: "ログアウトしますか？", disable_with: "送信中..." }, class: "red-btn"%>
-  </div>
+  <span class="block w-full m-auto max-w-sm">
+    <%= link_to "ログアウト", destroy_user_session_path, method: :delete, data: { confirm: "ログアウトしますか？", disable_with: "送信中..." }, class: "red-btn w-2/3  block m-auto"%>
+</span>
+
+</div>
 
   <!-- 管理者専用-->
+</div>
   <% if admin_user? %>
     <div class="text-left p-8">
       <h2 class="text-pink-500">管理者専用</h2>


### PR DESCRIPTION
## 実装の目的と概要
- ボタン幅の調整
## 実装内容(技術的な点を記載)
- [x] ボタン幅の調整

## スクリーンショット（画面レイアウトを変更した場合）
<img width="834" alt="スクリーンショット 2021-06-10 9 09 12" src="https://user-images.githubusercontent.com/64491435/121445079-b9579180-c9cb-11eb-88fc-00b766def0ce.png">
<img width="834" alt="スクリーンショット 2021-06-10 9 08 39" src="https://user-images.githubusercontent.com/64491435/121445088-bceb1880-c9cb-11eb-8d45-d02e95a8ea4f.png">

## チェックリスト

- [x] ローカル環境での動作確認をしたか（影響し得る範囲も含めて）
- [x] rubocopを実行して警告が出力されていないか
- [x] GitHub で ファイル差分（Files changed）を確認し、内容が合っているか。不要なファイルに差分がでていないか
- [x] テストでエラーが発生していないか
