### PR TITLE
[レイアウト]フッターの余白の調整

### DIFF
--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -78,10 +78,9 @@
 }
 
 //************ フォーム **************//
-//消すかリファクタリングで使用するか
-// .form-body {
-//   @apply  
-// }
+.form-body {
+  @apply pt-8 pb-16 
+}
 
 .form-title {
   @apply text-lg block mt-8 mb-4 text-left text-gray-500 border-l-4 pl-2 border-dekiru-blue max-w-4xl mx-auto
@@ -144,4 +143,3 @@ iframe {
   width: 100%;
   height: 100%;
 }
-

--- a/app/views/categories/_form.html.erb
+++ b/app/views/categories/_form.html.erb
@@ -1,9 +1,9 @@
 <%= form_with model: @category, local: true do |f| %>
-  <div class="form-body">
+  <div class="form-body mt-8">
     <%= render 'layouts/error_messages', model: f.object %>
     <h2 class="form-title">カテゴリー名<span class="required_content">必須</span></h2>
     <%= f.text_field :name , placeholder: "カテゴリー名(16文字以内)", required: true, class: "text-field" %>
-    <div>
+    <div class="my-8">
       <%= f.submit "確定する", data: { confirm: '確定します。よろしいでしょうか？', disable_with: "送信中..." }, class:"submit-btn" %>
     </div>
   </div>

--- a/app/views/categories/index.html.erb
+++ b/app/views/categories/index.html.erb
@@ -1,7 +1,7 @@
-<div class="my-8">
+<div class="pt-16 pb-52 mx-auto max-w-6xl">
   <h1 class="py-8">カテゴリー一覧画面</h1>
   <div class="pt-16 pb-32">
-    <div class="flex justify-start flex-wrap my-2">
+    <div class="flex justify-center md:justify-start flex-wrap my-1">
       <%= render partial: "category_card", collection: @categories, as: "category" %>
     </div>
   </div>

--- a/app/views/categories/new.html.erb
+++ b/app/views/categories/new.html.erb
@@ -1,6 +1,6 @@
-<h1 class="mt-8 mb-2">カテゴリー作成</h1>
-<%= link_to ">>マイページへ戻る", mypage_path(current_user), class:"blue-link" %>
-
-<%= render "form"%>
-
+<%= link_to ">>マイページへ戻る", mypage_path(current_user), class:"blue-link text-left block my-4" %>
+<div class="mb-32">
+  <h1 class="mt-16">カテゴリー作成</h1>
+  <%= render "form"%>
+</div>
 <%#= render "category_card"%>

--- a/app/views/contacts/index.html.erb
+++ b/app/views/contacts/index.html.erb
@@ -1,24 +1,26 @@
-<h1 class="mt-16 mb-12">お問い合わせ<%= " 《確認》" if @contact.submitted == "1" %></h1>
-<div class="pb-8">
-  <%= form_with model: @contact, local: true do |form| %>
-    <div class="form-body">
-
-      <%= render 'layouts/error_messages', model: form.object %>
-      <%= form.hidden_field :submitted %>
-
-      <% if @contact.submitted == "1" %>
-        <%# 確認画面 %>
-        <%= render "confirm_fields", form: form %>
-        <div>
-          <div class="mt-4"><%= form.button "戻る", name: "contact[confirmed]", value: "", class:"submit-btn" %></div>
-          <div><%= form.button "送信", name: "contact[confirmed]", value: "1", data: { disable_with: "送信中..." }, class:"submit-btn" %></div>
-        </div>
-          <% else %>
-        <%# 投稿画面 %>
-        <%= render "submit_fields", form: form %>
-        <div class="py-8"><%= form.submit "確認", class:"submit-btn" %></div>
-      <% end %>
-
-    </div>
-  <% end %>
+<div class="py-8">
+  <h1 class="mt-16 mb-12">お問い合わせ<%= " 《確認》" if @contact.submitted == "1" %></h1>
+  <div class="pb-8">
+    <%= form_with model: @contact, local: true do |form| %>
+      <div class="form-body">
+  
+        <%= render 'layouts/error_messages', model: form.object %>
+        <%= form.hidden_field :submitted %>
+  
+        <% if @contact.submitted == "1" %>
+          <%# 確認画面 %>
+          <%= render "confirm_fields", form: form %>
+          <div>
+            <div class="mt-4"><%= form.button "戻る", name: "contact[confirmed]", value: "", class:"submit-btn" %></div>
+            <div><%= form.button "送信", name: "contact[confirmed]", value: "1", data: { disable_with: "送信中..." }, class:"submit-btn" %></div>
+          </div>
+            <% else %>
+          <%# 投稿画面 %>
+          <%= render "submit_fields", form: form %>
+          <div class="py-8"><%= form.submit "確認", class:"submit-btn" %></div>
+        <% end %>
+  
+      </div>
+    <% end %>
+  </div>
 </div>

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -1,6 +1,6 @@
 <footer class="bg-dekiru-base py-8 text-center border">
 
-  <div class="p-4 md:flex md:mx-20 xl:mx-80">
+  <div class="p-4 md:flex md:mx-20 xl:mx-60">
 
     <!-- ロゴ -->
     <div class="p-4 mx-auto max-w-xs md:w-1/2 md:ml-0">

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,5 +1,5 @@
 <header class="sticky top-0 z-10 p-1 text-center bg-dekiru-base">
-  <div class="mx-4 md:mx-20 xl:mx-80 py-4 flex text-center justify-center items-center">
+  <div class="mx-4 md:mx-20 xl:mx-60 py-4 flex text-center justify-center items-center">
 
     <!-- ロゴ -->
     <div class="flex-grow w-3/12">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>DEKIRU</title>
+    <title>deKiRU</title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
@@ -10,7 +10,7 @@
   <body>
     <%= render "layouts/flash" %>
     <%= render "layouts/header" %>
-    <div class="text-center mx-4 md:mx-20 xl:mx-80">
+    <div class="text-center mx-4 md:mx-20 xl:mx-60">
       <%= yield %>
     </div>
     <%= render "layouts/footer"%>

--- a/app/views/makes/edit.html.erb
+++ b/app/views/makes/edit.html.erb
@@ -1,3 +1,4 @@
-<h1 class="my-8">作り方を編集</h1>
-
-<%= render "form"%>
+<div class="pt-16 pb-32">
+  <h1 class="my-8">作り方を編集</h1>
+  <%= render "form"%>
+</div>

--- a/app/views/makes/new.html.erb
+++ b/app/views/makes/new.html.erb
@@ -1,3 +1,4 @@
-<h1 class="my-8">作り方を追加</h1>
-
-<%= render "form"%>
+<div class="pt-16 pb-32">
+  <h1 class="my-8">作り方を追加</h1>
+  <%= render "form"%>
+</div>

--- a/app/views/responses/_form.html.erb
+++ b/app/views/responses/_form.html.erb
@@ -3,7 +3,7 @@
   <div class="mb-8">
     <span class="text-lg border-b border-dekiru-blue">質問内容</span>
   </div>
-  <div>
+  <div class="max-w-2xl mx-auto text-left">
     <%= Question.find_by(@question).question_content %>
   </div>
 </div>

--- a/app/views/reviews/new.html.erb
+++ b/app/views/reviews/new.html.erb
@@ -1,28 +1,31 @@
-<h1 class="my-8">レビュー登録</h1>
-
-<%= form_with model: @review, local: true do |f| %>
-  <div class="form-body">
-    <%= render 'layouts/error_messages', model: f.object %>
+<div class=" my-20">
+  <h1 class="mt-8">レビュー登録</h1>
   
-    <%= f.hidden_field :content_id, value: @content_id %>
-  
-      <div class="field pb-4">
-        <h2 class="form-title">写真<span class="required_content">必須</span></h2>
-        <div class="max-w-4xl mx-auto">
-          <%#= image_tag @user.thumbnail.url, id: :img_prev ,class:"my-4 border-4 border-gray-300"%>
-          <label class="file_field" for="review_image">選択する</label>
-          <%= f.file_field :thumbnail, id: "review_image", accept: "image/png,image/jpeg", class: "hidden" %>
+  <%= form_with model: @review, local: true do |f| %>
+    <div class="form-body pb-16">
+      <%= render 'layouts/error_messages', model: f.object %>
+    
+      <%= f.hidden_field :content_id, value: @content_id %>
+    
+        <div class="field pb-4">
+          <h2 class="form-title">写真<span class="required_content">必須</span></h2>
+          <div class="max-w-4xl mx-auto">
+            <%#= image_tag @user.thumbnail.url, id: :img_prev ,class:"my-4 border-4 border-gray-300"%>
+            <label class="file_field" for="review_image">選択する</label>
+            <%= f.file_field :thumbnail, id: "review_image", accept: "image/png,image/jpeg", class: "hidden" %>
+          </div>
         </div>
+  
+      <div>
+        <div class="form-title">レビュー<span class="required_content">必須</span></div>
+        <%= f.text_area :comment, placeholder: "レビュー内容(500文字以内)",required: true, class:"text-area" %>
       </div>
-
-    <div>
-      <div class="form-title">レビュー<span class="required_content">必須</span></div>
-      <%= f.text_area :comment, placeholder: "レビュー内容(500文字以内)",required: true, class:"text-area" %>
+  
+      <div class="mt-8">
+        <%= f.submit "確定する", data: { confirm: '確定します。よろしいでしょうか？', disable_with: "送信中..."}, class:"submit-btn" %>
+      </div>
+  
     </div>
+  <% end %>
 
-    <div>
-      <%= f.submit "確定する", data: { confirm: '確定します。よろしいでしょうか？', disable_with: "送信中..."}, class:"submit-btn" %>
-    </div>
-
-  </div>
-<% end %>
+</div>

--- a/app/views/tag_masters/_form.html.erb
+++ b/app/views/tag_masters/_form.html.erb
@@ -11,7 +11,7 @@
     <!-- タグタイプ -->
     <%#= f.text_area :detail %>
     
-    <div>
+    <div class="my-8">
       <%= f.submit "確定する", data: { confirm: '確定します。よろしいでしょうか？', disable_with: "送信中..."}, class:"submit-btn" %>
     </div>
   </div>

--- a/app/views/tag_masters/edit.html.erb
+++ b/app/views/tag_masters/edit.html.erb
@@ -1,3 +1,4 @@
-<h1 class="my-8">タグを編集</h1>
-
-<%= render "form"%>
+<div class="my-32">
+  <h1 class="mt-16">タグを編集</h1>
+  <%= render "form"%>
+</div>

--- a/app/views/tag_masters/new.html.erb
+++ b/app/views/tag_masters/new.html.erb
@@ -1,3 +1,4 @@
-<h1 class="my-8">タグを追加</h1>
-
-<%= render "form"%>
+<div class="my-32">
+  <h1 class="mt-16">タグを追加</h1>
+  <%= render "form"%>
+</div>

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -31,6 +31,6 @@
   </div>
 <% end %>
 
-<div class="mt-4 mb-8">
+<div class="mt-4 mb-16">
   <%= render "users/shared/links" %>
 </div>


### PR DESCRIPTION
## 実装の目的と概要
- フッターの下に余白が発生しないように各ページを調整

## チェックリスト

- [x] ローカル環境での動作確認をしたか（影響し得る範囲も含めて）
- [x] rubocopを実行して警告が出力されていないか
- [x] GitHub で ファイル差分（Files changed）を確認し、内容が合っているか。不要なファイルに差分がでていないか
- [x] テストでエラーが発生していないか
