### PR TITLE
[レイアウト]プレースホルダーの位置を調整

### DIFF
--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -87,11 +87,20 @@
 }
 
 .text-field {
-  @apply border   text-dekiru-font w-full py-2 focus:outline-none focus:ring-1 focus:ring-dekiru-blue focus:ring-opacity-50 focus:border-dekiru-blue max-w-4xl resize-none rounded
+  @apply border text-dekiru-font w-full py-2 focus:outline-none focus:ring-1 focus:ring-dekiru-blue focus:ring-opacity-50 focus:border-dekiru-blue max-w-4xl resize-none rounded
+}
+
+//プレースホルダー
+.text-field::placeholder {
+  @apply px-2 py-4
 }
 
 .text-area {
   @apply border text-dekiru-font w-full py-8 focus:outline-none focus:ring-1 focus:ring-dekiru-blue focus:ring-opacity-30 focus:border-dekiru-blue max-w-4xl resize-none rounded
+}
+
+.text-area::placeholder {
+  @apply px-2 py-4
 }
 
 //TODO: text-fieldは将来的にこちらを実装する予定


### PR DESCRIPTION
## 実装の目的と概要
- プレースホルダーの位置を調整
## 実装内容(技術的な点を記載)
- プレースホルダーの位置を調整(文字とフォームの間に少しスペースを設ける)

 ## スクリーンショット（画面レイアウトを変更した場合）
<img width="834" alt="スクリーンショット 2021-06-10 10 26 25" src="https://user-images.githubusercontent.com/64491435/121450379-97174100-c9d6-11eb-9b70-55b26a623a00.png">

## 参考資料
- [【rails】CSSでplaceholderの文字サイズを変更する方法](https://qiita.com/takaaaaaaaya/items/532348a97efd9682deb0)
## チェックリスト

- [x] ローカル環境での動作確認をしたか（影響し得る範囲も含めて）
- [x] rubocopを実行して警告が出力されていないか
- [x] GitHub で ファイル差分（Files changed）を確認し、内容が合っているか。不要なファイルに差分がでていないか
- [x] テストでエラーが発生していないか

## 備考（実装していないことなど）
