### PR TITLE
[レイアウト]カードのレイアウトを修正

### DIFF
--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -16,7 +16,7 @@
 //************ボタン**************//
 //ベース
 .base_btn {
- @apply text-white font-bold py-2 px-6 my-8 rounded-lg focus:outline-none shadow-lg 
+ @apply text-white font-bold py-2 px-6 my-8 rounded-lg focus:outline-none shadow-lg
 }
 
 //背景色・hover時の背景色

--- a/app/views/contents/_review_card.html.erb
+++ b/app/views/contents/_review_card.html.erb
@@ -1,17 +1,19 @@
-  <div class="border border-gray-300 md:w-1/3">
-  <!-- 写真 -->
-  <div class="m-4 m-auto md:p-2">
-    <%= image_tag review.image.thumb214.url, class:"w-full" %>
-  </div>
+<div class="md:w-1/3">
+  <div class="border bg-white m-2 shadow-lg rounded-2xl">
+    <!-- 写真 -->
+    <div class="m-auto">
+      <%= image_tag review.image.thumb214.url, class:"w-full rounded-t-2xl" %>
+    </div>
 
-  <!-- ユーザー情報 -->
-  <div class="flex justify-start p-4">
-    <%=image_tag review.user.thumbnail.thumb27.url,class:"rounded-full border-2 border-gray-300" %>
-    <span class="ml-4"><%= review.user.name %><span>
-  </div>
+    <!-- ユーザー情報 -->
+    <div class="flex justify-start p-4">
+      <%=image_tag review.user.thumbnail.thumb27.url,class:"rounded-full border-2 border-gray-300" %>
+      <span class="ml-4"><%= review.user.name %><span>
+    </div>
 
-  <!-- レビュー -->
-  <div class="text-left p-4">
-    <p><%= review.comment%></p>
+    <!-- レビュー -->
+    <div class="text-left p-4">
+      <p><%= review.comment%></p>
+    </div>
   </div>
 </div>

--- a/app/views/contents/show.html.erb
+++ b/app/views/contents/show.html.erb
@@ -97,17 +97,16 @@
   <!-- review -->
   <div class="mb-8 p-4 border bg-gray-100">
   
-    <div class="mb-4 bg-gray-100">
+    <div class="mb-4">
       <h2 class="pt-8 pm-4">レビュー</h2>
       <% if general_user? %>
         <div class="px-4 py-2 text-right">
           <%= link_to ">>レビューする", new_review_path(params: { content_id: @content.id }), class:"blue-link" %>
         </div>
-  
       <% end %>
   
       <!-- レビューカード -->
-      <div class="md:flex justify-start flex-wrap bg-white">
+      <div class="md:flex justify-start flex-wrap bg-white bg-gray-100">
         <%= render partial: "review_card", collection: @reviews, as: "review" %>
       </div>
     </div>

--- a/app/views/homes/index.html.erb
+++ b/app/views/homes/index.html.erb
@@ -15,7 +15,7 @@
   </div>
   
   <div class="md:flex justify-center py-8 mb:py-16">
-    <%= render partial: "layouts/content_card", collection: @popularity_contents, as: "content" %>
+    <%= render partial: "layouts/top_page_content_card", collection: @popularity_contents, as: "content" %>
   </div>
 </div>
 
@@ -28,7 +28,7 @@
       </div>
     </div>
   <div class="md:flex justify-center py-8 mb:py-16">
-    <%= render partial: "layouts/content_card", collection: @recommend_contents, as: "content" %>
+    <%= render partial: "layouts/top_page_content_card", collection: @recommend_contents, as: "content" %>
   </div>
 </div>
 
@@ -41,7 +41,7 @@
     </div>
   </div>
   <div class="md:flex justify-center py-8 mb:py-16">
-    <%= render partial: "layouts/content_card", collection: @new_contents, as: "content" %>
+    <%= render partial: "layouts/top_page_content_card", collection: @new_contents, as: "content" %>
   </div>
 </div>
 
@@ -53,7 +53,7 @@
     </div>
   </div>
     <!-- 横にして！-->
-   <div class="md:flex justify-center py-8 mb:py-16">
+   <div class="py-8 mb:py-16">
     <%= render partial: "layouts/category_contents_card", collection: @categories, as: "category" %>
   </div>
 </div>

--- a/app/views/homes/index.html.erb
+++ b/app/views/homes/index.html.erb
@@ -14,7 +14,7 @@
     </div>
   </div>
   
-  <div class="md:flex justify-center">
+  <div class="md:flex justify-center py-8 mb:py-16">
     <%= render partial: "layouts/content_card", collection: @popularity_contents, as: "content" %>
   </div>
 </div>
@@ -27,7 +27,7 @@
         <%= link_to ">>全て見る", recommend_contents_path, class:"blue-link" %>
       </div>
     </div>
-  <div class="md:flex justify-center">
+  <div class="md:flex justify-center py-8 mb:py-16">
     <%= render partial: "layouts/content_card", collection: @recommend_contents, as: "content" %>
   </div>
 </div>
@@ -40,7 +40,7 @@
       <%= link_to ">>全て見る", newest_contents_path, class:"blue-link" %>
     </div>
   </div>
-  <div class="md:flex justify-center">
+  <div class="md:flex justify-center py-8 mb:py-16">
     <%= render partial: "layouts/content_card", collection: @new_contents, as: "content" %>
   </div>
 </div>
@@ -53,7 +53,7 @@
     </div>
   </div>
     <!-- 横にして！-->
-   <div class="md:flex  justify-center">
+   <div class="md:flex justify-center py-8 mb:py-16">
     <%= render partial: "layouts/category_contents_card", collection: @categories, as: "category" %>
   </div>
 </div>

--- a/app/views/layouts/_category_contents_card.html.erb
+++ b/app/views/layouts/_category_contents_card.html.erb
@@ -1,7 +1,7 @@
-<div>
+<div class="flex">
   <div class="text-lg"><%= category.name %></div>
   <%= link_to ">>このカテゴリーへ移動" , category_path(category.id), class: "blue-link" %>
-    <%= render partial: "layouts/content_card", collection: category.contents.first(3), as: "content" %>
-      <% category.contents.first(3).each do |content|%>
+    <%= render partial: "layouts/content_card", collection: category.contents.first(2), as: "content" %>
+      <% category.contents.first(2).each do |content|%>
     <% end %>
 </div>

--- a/app/views/layouts/_category_contents_card.html.erb
+++ b/app/views/layouts/_category_contents_card.html.erb
@@ -1,7 +1,9 @@
-<div class="flex">
-  <div class="text-lg"><%= category.name %></div>
-  <%= link_to ">>このカテゴリーへ移動" , category_path(category.id), class: "blue-link" %>
-    <%= render partial: "layouts/content_card", collection: category.contents.first(2), as: "content" %>
-      <% category.contents.first(2).each do |content|%>
-    <% end %>
+<div class="py-8">
+  <h2 class="text-lg"><%= category.name %></h2>
+  <div>
+    <%= link_to ">>このカテゴリーへ移動" , category_path(category.id), class: "blue-link" %>
+     <div class="flex">
+      <%= render partial: "layouts/top_page_content_card", collection: category.contents.first(2), as: "content" %>
+    </div>
+  </div>
 </div>

--- a/app/views/layouts/_content_card.html.erb
+++ b/app/views/layouts/_content_card.html.erb
@@ -1,8 +1,11 @@
+<div class="md:w-1/2 xl:w-11/12">
 <%= link_to content_show_path(content.id) do %>
-  <div class="w-11/12 m-4 max-w-md mx-auto my-4 shadow-x1 overflow-hidden bg-white rounded shadow-lg">
+  <div class="w-11/12 max-w-lg mx-auto m-4 shadow-x1 overflow-hidden bg-white rounded shadow-lg">
     <%= image_tag youtube_thumbnail(content.movie_id), class:"w-full object-cover" %>
-    <div class="py-4 text-lg text-dekiru-font text-sm">
+    <div class="px-4 py-2 text-md text-dekiru-font text-sm">
       <%= content.title %>
     </div>
   </div>
 <% end %>
+
+</div>

--- a/app/views/layouts/_top_page_content_card.html.erb
+++ b/app/views/layouts/_top_page_content_card.html.erb
@@ -1,4 +1,4 @@
-<div class="md:w-1/2 xl:w-1/3">
+<div class="md:w-1/2">
 <%= link_to content_show_path(content.id) do %>
   <div class="w-11/12 max-w-lg mx-auto m-4 shadow-x1 overflow-hidden bg-white rounded shadow-lg">
     <%= image_tag youtube_thumbnail(content.movie_id), class:"w-full object-cover" %>

--- a/app/views/reviews/new.html.erb
+++ b/app/views/reviews/new.html.erb
@@ -12,7 +12,7 @@
           <div class="max-w-4xl mx-auto">
             <%#= image_tag @user.thumbnail.url, id: :img_prev ,class:"my-4 border-4 border-gray-300"%>
             <label class="file_field" for="review_image">選択する</label>
-            <%= f.file_field :thumbnail, id: "review_image", accept: "image/png,image/jpeg", class: "hidden" %>
+            <%= f.file_field :image, id: "review_image", accept: "image/png,image/jpeg", class: "hidden" %>
           </div>
         </div>
   

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -3,4 +3,4 @@
 recommend_content_num: 9 # おすすめコンテンツの最大数
 per_page: 12 # 1ページの表示数
 max_countent_tags: 3 # タグ可能数
-top_page_content: 3 # TOPページに表示するコンテンツ
+top_page_content: 2 # TOPページに表示するコンテンツ


### PR DESCRIPTION
## 実装の目的と概要
- カードのレイアウトを修正
## 実装内容(技術的な点を記載)
- カードのレイアウトを修正
- トップページを3列から2列に変更

## スクリーンショット（画面レイアウトを変更した場合）
<img width="1680" alt="スクリーンショット 2021-06-10 14 08 31" src="https://user-images.githubusercontent.com/64491435/121468387-abb70180-c9f5-11eb-9bcd-72bf099af48b.png">
<img width="837" alt="スクリーンショット 2021-06-10 14 03 38" src="https://user-images.githubusercontent.com/64491435/121468379-a8bc1100-c9f5-11eb-9d85-582d3cb3a807.png">
<img width="842" alt="スクリーンショット 2021-06-10 14 08 21" src="https://user-images.githubusercontent.com/64491435/121468386-aa85d480-c9f5-11eb-90df-8e7c85c43aeb.png">

## チェックリスト

- [x] ローカル環境での動作確認をしたか（影響し得る範囲も含めて）
- [x] rubocopを実行して警告が出力されていないか
- [x] GitHub で ファイル差分（Files changed）を確認し、内容が合っているか。不要なファイルに差分がでていないか
- [x] テストでエラーが発生していないか
