### PR TITLE
[機能開発]おすすめコンテンツのステータス更新機能の実装/制限

### DIFF
--- a/app/controllers/contents_controller.rb
+++ b/app/controllers/contents_controller.rb
@@ -49,7 +49,7 @@ class ContentsController < ApplicationController
 
   def destroy
     @content.destroy!
-    redirect_to contents_path, alert: "【#{@content.title}】を削除しました"
+    redirect_to root_path, alert: "【#{@content.title}】を削除しました"
   end
 
   def popular

--- a/app/controllers/contents_controller.rb
+++ b/app/controllers/contents_controller.rb
@@ -81,6 +81,7 @@ class ContentsController < ApplicationController
 
     def content_params
       movie_id = YoutubeUrlFormatter.movie_id_format(params[:content][:movie_url])
-      params.require(:content).permit(:title, :subtitle, :movie_url, :comment, :point, :public_status, :category_id, tag_master_ids: []).merge(movie_id: movie_id)
+      params.require(:content).permit(:title, :subtitle, :movie_url, :comment, :point, :public_status, :recommend_status, :category_id,
+                                      tag_master_ids: []).merge(movie_id: movie_id)
     end
 end

--- a/app/models/content.rb
+++ b/app/models/content.rb
@@ -9,22 +9,24 @@ class Content < ApplicationRecord
   has_many :tag_masters, through: :content_tags
   belongs_to :category, optional: true
 
+  # バリデージョン
   validates :title, presence: true, length: { in: 1..16, allow_blank: true }
   validates :subtitle, presence: true, length: { in: 1..32, allow_blank: true }
   validates :comment, presence: true, length: { in: 1..32, allow_blank: true }
   validates :point, presence: true, length: { in: 1..32, allow_blank: true }
-  validate :tag_master_ids, :content_tag_checker
   validates :movie_url, presence: true
+  validate :tag_master_ids, :content_tag_checker
 
+  # enum
   enum recommend_status: { general: 0, recommend: 1 }
   enum public_status: { non_published: 0, published: 1 }
 
   # CSV
   CSV_COLUMNS = %w[title subtitle movie_url comment point movie_id category_id].freeze
 
-  # TODO: サムネイル画像のURLを保存するかどうか検討
-  # mount_uploader :movie_thumbnail, MovieThumbnailUploader
+  # 定数
   MAX_CONTENT_TAGS = Settings.max_countent_tags
+  MAX_RECOMMEND_CONTENT = Settings.max_recommend_countent
 
   # お気に入り判定
   def favorited_by?(user)
@@ -44,6 +46,14 @@ class Content < ApplicationRecord
     else
       # 失敗した場合はバリデーションエラーを出す
       self.errors.add(:movie_url, "YouTubeのURL以外は無効です")
+      throw(:abort)
+    end
+  end
+
+  # おすすめコンテンツの登録数を制限
+  before_save do
+    if Content.find_by(id: self).general? && self.recommend? && Content.recommend.count >= MAX_RECOMMEND_CONTENT
+      self.errors.add(:recommend_status, "の登録できる上限を超えています。（おすすめコンテンツは#{MAX_RECOMMEND_CONTENT}つまで）")
       throw(:abort)
     end
   end
@@ -73,4 +83,7 @@ class Content < ApplicationRecord
       end
     end
   end
+
+  # TODO: サムネイル画像のURLを保存するかどうか検討
+  # mount_uploader :movie_thumbnail, MovieThumbnailUploader
 end

--- a/app/models/content.rb
+++ b/app/models/content.rb
@@ -14,9 +14,7 @@ class Content < ApplicationRecord
   validates :comment, presence: true, length: { in: 1..32, allow_blank: true }
   validates :point, presence: true, length: { in: 1..32, allow_blank: true }
   validate :tag_master_ids, :content_tag_checker
-  # TODO: movie_urlバリデージョン実装時に実装する
-  # validates :movie_url, presence: true
-  # validates recommend_status:, presence: true
+  validates :movie_url, presence: true
 
   enum recommend_status: { general: 0, recommend: 1 }
   enum public_status: { non_published: 0, published: 1 }

--- a/app/views/contents/_form.html.erb
+++ b/app/views/contents/_form.html.erb
@@ -54,6 +54,16 @@
       </div>
     </div>
 
+    <!-- おすすめ -->
+    <div class="max-w-4xl mx-auto">
+      <h2 class="form-title">おすすめコンテンツ</h2>
+      <div class="flex flex-wrap justify-start py-4 mb-8">
+        <span class="border-2 border-dekiru-blue px-4 py-2 shadow-sm text-left my-4">
+          <%= f.select :recommend_status, [ ["おすすめしない", "general"], ["おすすめする", "recommend"]], { prompt: "" },{ class:"focus:outline-none text-dekiru-font" } %>
+        </span>
+      </div>
+    </div>
+
    <!-- ステータス -->
    <div class="mx-auto max-w-4xl">
       <h2 class="form-title">ステータス</h2>

--- a/app/views/contents/_form.html.erb
+++ b/app/views/contents/_form.html.erb
@@ -56,7 +56,7 @@
 
     <!-- おすすめ -->
     <div class="max-w-4xl mx-auto">
-      <h2 class="form-title">おすすめコンテンツ</h2>
+      <h2 class="form-title">おすすめコンテンツ(<%= Content.recommend.count%>/<%= Settings.max_recommend_countent%>個)</h2>
       <div class="flex flex-wrap justify-start py-4 mb-8">
         <span class="border-2 border-dekiru-blue px-4 py-2 shadow-sm text-left my-4">
           <%= f.select :recommend_status, [ ["おすすめしない", "general"], ["おすすめする", "recommend"]], { prompt: "" },{ class:"focus:outline-none text-dekiru-font" } %>

--- a/app/views/layouts/_error_messages.html.erb
+++ b/app/views/layouts/_error_messages.html.erb
@@ -1,6 +1,6 @@
 <% if model.errors.any? %>
   <div class="mt-10 mb-20">
-  <div class="mx-auto max-w-4xl mb-10">
+  <div class="mx-auto max-w-4xl mb-10 text-red-700">
       <%= I18n.t("errors.messages.not_saved",
                  count: model.errors.count,
                  resource: model.class.model_name.human.downcase)

--- a/app/views/users/shared/_error_messages.html.erb
+++ b/app/views/users/shared/_error_messages.html.erb
@@ -1,6 +1,6 @@
 <% if resource.errors.any? %>
   <div class="mt-10 mb-20">
-    <div class="mx-auto max-w-4xl mb-10">
+    <div class="mx-auto max-w-4xl mb-10 text-red-700">
       <%= I18n.t("errors.messages.not_saved",
                    count: resource.errors.count,
                    resource: resource.class.model_name.human.downcase)

--- a/config/locales/enums.ja.yml
+++ b/config/locales/enums.ja.yml
@@ -4,3 +4,6 @@ ja:
       public_status:
         non_published: "未公開"
         published: "公開中"
+      recommend_status:
+        general: "一般コンテンツ"
+        recommend: "おすすめコンテンツ"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -7,6 +7,8 @@ ja:
         movie_url: URL
         comment: コメント
         point: ポイント
+        recommend_status: おすすめコンテンツ
+        public_status: 公開ステータス
       make:
         detail: 作り方
       material:
@@ -35,6 +37,7 @@ ja:
       make: 作り方
       material: 材料
       category: カテゴリー
+      content: コンテンツ
       user: ユーザー
       review: レビュー
       question: 質問

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -4,3 +4,4 @@ recommend_content_num: 9 # おすすめコンテンツの最大数
 per_page: 12 # 1ページの表示数
 max_countent_tags: 3 # タグ可能数
 top_page_content: 2 # TOPページに表示するコンテンツ
+max_recommend_countent: 9

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -78,6 +78,7 @@ ActiveRecord::Schema.define(version: 2021_06_14_023534) do
     t.bigint "category_id"
     t.integer "public_status", default: 0
     t.index ["category_id"], name: "index_contents_on_category_id"
+    t.index ["public_status"], name: "index_contents_on_public_status"
     t.index ["recommend_status"], name: "index_contents_on_recommend_status"
     t.index ["subtitle"], name: "index_contents_on_subtitle"
     t.index ["title"], name: "index_contents_on_title"

--- a/spec/models/content_spec.rb
+++ b/spec/models/content_spec.rb
@@ -110,6 +110,24 @@ RSpec.describe Content, type: :model do
         end
       end
 
+      describe "movie_url" do
+        context "urlが空の場合" do
+          let(:content) { build(:content, movie_url: "") }
+          it "エラーが発生する" do
+            expect(subject).to eq false
+            expect(content.errors.messages[:movie_url]).to include "を入力してください"
+          end
+        end
+
+        context "urlがyouyubeのURLでない場合" do
+          let(:content) { build(:content, movie_url: "https://www.yahoo.co.jp/") }
+          it "エラーが発生する" do
+            expect(content.save).to eq false
+            expect(content.errors.messages[:movie_url]).to include "YouTubeのURL以外は無効です"
+          end
+        end
+      end
+
       describe "content_delete" do
         context "コンテンツが削除された時" do
           subject { content.destroy }

--- a/spec/requests/contents_request_spec.rb
+++ b/spec/requests/contents_request_spec.rb
@@ -253,7 +253,7 @@ RSpec.describe "Contents", type: :request do
         sign_in @admin
         expect { subject }.to change { Content.count }.by(-1)
         expect(response).to have_http_status(:found)
-        expect(response).to redirect_to contents_path
+        expect(response).to redirect_to root_path
         expect(flash[:alert]).to eq("【#{@content.title}】を削除しました")
       end
     end


### PR DESCRIPTION
## 実装の目的と概要
- おすすめコンテンツのステータス更新機能の実装/制限
## 実装内容(技術的な点を記載)
- おすすめコンテンツのステータス更新機能の実装
- おすすめコンテンツの数を制限

## スクリーンショット（画面レイアウトを変更した場合）
<img width="834" alt="スクリーンショット 2021-06-14 16 44 38" src="https://user-images.githubusercontent.com/64491435/121857048-281c4e00-cd30-11eb-861d-c3b4efbf4ae0.png">
<img width="834" alt="スクリーンショット 2021-06-14 16 44 42" src="https://user-images.githubusercontent.com/64491435/121857066-2bafd500-cd30-11eb-96a6-6529a6ba1fa5.png">

## チェックリスト

- [x] ローカル環境での動作確認をしたか（影響し得る範囲も含めて）
- [x] rubocopを実行して警告が出力されていないか
- [x] GitHub で ファイル差分（Files changed）を確認し、内容が合っているか。不要なファイルに差分がでていないか
- [x] テストでエラーが発生していないか

## 備考（実装していないことなど）
