### PR TITLE
[機能開発]停止ユーザーのログインを制限

### DIFF
--- a/app/admin/users.rb
+++ b/app/admin/users.rb
@@ -1,0 +1,22 @@
+ActiveAdmin.register User do
+  # 管理画面で削除は行わない
+  actions :all, except: [:destroy]
+
+  # 変更できるのはユーザータイプのみ
+  permit_params :user_type
+
+  index do
+    selectable_column
+    id_column
+    column :email
+    column :user_type, :user_type_i18n, sortable: :user_type
+    actions
+  end
+
+  form do |f|
+    f.inputs do
+      f.input :user_type, as: :select, collection: User.user_types_i18n.invert
+    end
+    f.actions
+  end
+end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -2,6 +2,7 @@
 
 class Users::SessionsController < Devise::SessionsController
   # before_action :configure_sign_in_params, only: [:create]
+  before_action :discontinued_user_checker, only: [:create] # rubocop:disable all
 
   # ゲストアカウントでログイン
   def guest_sign_in
@@ -10,6 +11,15 @@ class Users::SessionsController < Devise::SessionsController
     redirect_to root_path, notice: "ゲストユーザーとしてログインしました。「レビュー」「質問」「お気に入り」「お問い合わせ」が実施できます"
   end
 
+  protected
+
+    # 停止ユーザーはログインできない
+    def discontinued_user_checker
+      @user = User.find_by(email: params[:user][:email].downcase)
+      if @user.discontinued?
+        redirect_to new_user_session_path, alert: "このアカウントではログインすることができません。"
+      end
+    end
   # GET /resource/sign_in
   # def new
   #   super

--- a/app/models/content.rb
+++ b/app/models/content.rb
@@ -52,7 +52,7 @@ class Content < ApplicationRecord
 
   # おすすめコンテンツの登録数を制限
   before_save do
-    if Content.find_by(id: self).general? && self.recommend? && Content.recommend.count >= MAX_RECOMMEND_CONTENT
+    if self.recommend? && self.recommend_status_was == "general" && Content.recommend.count >= MAX_RECOMMEND_CONTENT
       self.errors.add(:recommend_status, "の登録できる上限を超えています。（おすすめコンテンツは#{MAX_RECOMMEND_CONTENT}つまで）")
       throw(:abort)
     end

--- a/app/views/contents/_form.html.erb
+++ b/app/views/contents/_form.html.erb
@@ -54,25 +54,27 @@
       </div>
     </div>
 
-    <!-- おすすめ -->
-    <div class="max-w-4xl mx-auto">
-      <h2 class="form-title">おすすめコンテンツ(<%= Content.recommend.count%>/<%= Settings.max_recommend_countent%>個)</h2>
-      <div class="flex flex-wrap justify-start py-4 mb-8">
-        <span class="border-2 border-dekiru-blue px-4 py-2 shadow-sm text-left my-4">
-          <%= f.select :recommend_status, [ ["おすすめしない", "general"], ["おすすめする", "recommend"]], { prompt: "" },{ class:"focus:outline-none text-dekiru-font" } %>
-        </span>
+    <% if controller.action_name == "edit" %>
+      <!-- おすすめ -->
+      <div class="max-w-4xl mx-auto">
+        <h2 class="form-title">おすすめコンテンツ(<%= Content.recommend.count%>/<%= Settings.max_recommend_countent%>個)</h2>
+        <div class="flex flex-wrap justify-start py-4 mb-8">
+          <span class="border-2 border-dekiru-blue px-4 py-2 shadow-sm text-left my-4">
+            <%= f.select :recommend_status, [ ["おすすめしない", "general"], ["おすすめする", "recommend"]], { prompt: "" },{ class:"focus:outline-none text-dekiru-font" } %>
+          </span>
+        </div>
       </div>
-    </div>
 
-   <!-- ステータス -->
-   <div class="mx-auto max-w-4xl">
-      <h2 class="form-title">ステータス</h2>
-      <div class="py-4 text-left">
-        <span class="border-2 border-dekiru-blue px-4 py-2 shadow-sm text-left my-4">
-          <%= f.select :public_status, [ ["未公開", "non_published"], ["公開する", "published"]], { prompt: "" },{ class:"focus:outline-none text-dekiru-font" } %>
-        </span>
+       <!-- ステータス -->
+       <div class="mx-auto max-w-4xl">
+        <h2 class="form-title">ステータス</h2>
+        <div class="py-4 text-left">
+          <span class="border-2 border-dekiru-blue px-4 py-2 shadow-sm text-left my-4">
+            <%= f.select :public_status, [ ["未公開", "non_published"], ["公開する", "published"]], { prompt: "" },{ class:"focus:outline-none text-dekiru-font" } %>
+          </span>
+        </div>
       </div>
-    </div>
+    <% end %>
 
     <div class="my-16">
       <%= f.submit "確定する", data: { confirm: '確定します。よろしいでしょうか？', disable_with: "送信中..."}, class:"submit-btn" %>

--- a/app/views/users/admin.html.erb
+++ b/app/views/users/admin.html.erb
@@ -4,33 +4,13 @@
   <!-- コンテンツ -->
   <div class="my-8">
     <h2>1.コンテンツ</h2>
-    <!-- 新規作成リンク(管理者のみ) -->
     <div><%= link_to ">>新規作成",new_content_path, class:"admin-link" %></div>
     <div><%= link_to ">>コンテンツ一覧",contents_path, class:"admin-link" %></div>
   </div>
 
-  <!-- カテゴリー -->
-  <div class="my-8 ">
-    <h2>2.カテゴリー</h2>
-    <div>
-      <div><%= link_to ">>追加", new_category_path, class:"admin-link" %></div>
-      <div><%= link_to ">>カテゴリー一覧",admin_categories_path, class:"admin-link" %></div>
-    </div>
-  </div>
-
-  <!-- タグ -->
-  <div class="my-8">
-    <h2>3.タグ</h2>
-    <div class="my-4">
-      <div><%= link_to ">>追加", new_tag_master_path, class:"admin-link" %></div>
-      <div><%= link_to ">>タグ一覧", admin_tag_masters_path, class:"admin-link" %></div>
-      <%= render partial: "layouts/content_tag", collection: @content_tags, as: "tag" %>
-    </div>
-  </div>
-
   <!-- 質問 -->
   <div class="my-8">
-    <h2>4.質問</h2>
+    <h2>2.質問</h2>
     <div class="my-4">未回答：<%= Question.before.count %>件</div>
     <div class="my-4">
       <div><%= link_to ">>質問一覧", questions_path, class:"admin-link" %></div>
@@ -38,9 +18,34 @@
     </div>
   </div>
 
+  <!-- ユーザー -->
+  <div class="my-8">
+    <h2>3.ユーザー</h2>
+    <div><%= link_to ">>ユーザー一覧",admin_users_path, class:"admin-link" %></div>
+  </div>
+
+  <!-- タグ -->
+  <div class="my-8">
+    <h2>4.タグ</h2>
+    <div class="my-4">
+      <div><%= link_to ">>追加", new_tag_master_path, class:"admin-link" %></div>
+      <div><%= link_to ">>タグ一覧", admin_tag_masters_path, class:"admin-link" %></div>
+      <%= render partial: "layouts/content_tag", collection: @content_tags, as: "tag" %>
+    </div>
+  </div>
+
+  <!-- カテゴリー -->
+  <div class="my-8 ">
+    <h2>5.カテゴリー</h2>
+    <div>
+      <div><%= link_to ">>追加", new_category_path, class:"admin-link" %></div>
+      <div><%= link_to ">>カテゴリー一覧",admin_categories_path, class:"admin-link" %></div>
+    </div>
+  </div>
+
   <!-- お問い合わせ -->
   <div class="my-8">
-    <h2>5.お問い合わせ</h2>
+    <h2>6.お問い合わせ</h2>
     <div class="my-4">
       <div><%= link_to ">>質問一覧", admin_contacts_path, class:"admin-link" %></div>
       <div><%= render partial: "layouts/content_tag", collection: @content_tags, as: "tag" %></div>
@@ -49,7 +54,7 @@
 
   <!-- CSVインポート-->
   <div class="my-8">
-    <h2>6.インポート<span class="text-sm px-4">(コンテンツ)</span></h2>
+    <h2>7.インポート<span class="text-sm px-4">(コンテンツ)</span></h2>
     <%= form_with url: import_path do |f| %>
       <div class="max-w-4xl">
         <div class="my-4">
@@ -63,7 +68,7 @@
 
   <!-- CSVエクスポート-->
   <div class="my-8">
-    <h2>7.エクスポート<span class="text-sm px-4">(コンテンツ)</span></h2>
+    <h2>8.エクスポート<span class="text-sm px-4">(コンテンツ)</span></h2>
     <span class="my-4 block"><%= link_to "エクスポートを開始する", contents_path(format: :csv), data: { confirm: 'エクスポートします。よろしいでしょうか？', disable_with: "送信中..."}, class:"admin-btn" %></span>
   </div>
 

--- a/config/locales/enums.ja.yml
+++ b/config/locales/enums.ja.yml
@@ -1,5 +1,10 @@
 ja:
   enums:
+    user:
+      user_type:
+        general: "一般ユーザー"
+        admin: "管理者ユーザー"
+        discontinued: "停止ユーザー"
     content:
       public_status:
         non_published: "未公開"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,6 +1,10 @@
 ja:
   activerecord:
     attributes:
+      user:
+        general: "一般ユーザー"
+        admin: "管理者ユーザー"
+        discontinued: "停止ユーザー"
       content:
         title: タイトル
         subtitle: サブタイトル

--- a/spec/requests/contents_request_spec.rb
+++ b/spec/requests/contents_request_spec.rb
@@ -304,7 +304,7 @@ RSpec.describe "Contents", type: :request do
     context "おすすめコンテンツが存在する場合" do
       before { create_list(:content, create_content, recommend_status: "recommend", public_status: "published") }
 
-      it "おすすめコンテンツ一覧を取得できること" do
+      it "おすすめコンテンツ一覧を取得できること", type: :do do
         subject
         expect(response).to have_http_status(:ok)
         expect(response.body).to include(*Content.recommend.pluck(:title))


### PR DESCRIPTION
## 実装の目的と概要
- 停止ユーザーのログインを制限する機能を実装

## 実装内容(技術的な点を記載)
- 停止ユーザーのログインを制限する機能を実装
- adminでステータスを変更できるように修正

## スクリーンショット（画面レイアウトを変更した場合）
<img width="834" alt="スクリーンショット 2021-06-14 19 23 56" src="https://user-images.githubusercontent.com/64491435/121878681-f6fb4800-cd46-11eb-9427-6648cd2e1c98.png">

## 参考資料
- [Railsでモデルの変更前後の値](https://morizyun.github.io/ruby/active-record-attribute-was-change.html)
- [[Ruby/Rails] 例外で深くなったネストをGuard Clauseですっきりさせる](https://techracho.bpsinc.jp/hachi8833/2016_10_11/269500)
- [[rails]activeadminで作成した管理画面を日本語化する](https://qiita.com/w-tdon/items/6a2fb917d2f9aee2d078)
## チェックリスト

- [x] ローカル環境での動作確認をしたか（影響し得る範囲も含めて）
- [x] rubocopを実行して警告が出力されていないか
- [x] GitHub で ファイル差分（Files changed）を確認し、内容が合っているか。不要なファイルに差分がでていないか
- [x] テストでエラーが発生していないか
