### PR TITLE
[レイアウト]webフォントの実装,トップページの調整,トップへ戻るボタンの実装等

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -7,7 +7,7 @@ require("@rails/ujs").start()
 require("turbolinks").start()
 require("@rails/activestorage").start()
 require("channels")
-require('jquery')
+require("jquery")
 
 
 // Uncomment to copy all static images under ../images to the output folder and reference
@@ -18,5 +18,6 @@ require('jquery')
 // const imagePath = (name) => images(name, true)
 
 import "stylesheets/application"
-import "./counter.js"
+import "./counter"
 import "./accordion"
+import "./pageTop"

--- a/app/javascript/packs/pageTop.js
+++ b/app/javascript/packs/pageTop.js
@@ -1,0 +1,19 @@
+$(function() {
+  var topBtn = $('#page-top');    
+  topBtn.hide();
+  //スクロールが100に達したらボタン表示
+  $(window).scroll(function () {
+      if ($(this).scrollTop() > 100) {
+          topBtn.fadeIn();
+      } else {
+          topBtn.fadeOut();
+      }
+  });
+  //スクロールしてトップ
+  topBtn.click(function () {
+      $('body,html').animate({
+          scrollTop: 0
+      }, 500);
+      return false;
+  });
+});

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -1,3 +1,6 @@
+//webフォント
+@import url('https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@300;500&display=swap');
+
 @import "tailwindcss/base";
 @import "tailwindcss/components";
 @import "tailwindcss/utilities";
@@ -5,6 +8,9 @@
 
 //************ BASE **************//
 @layer base {
+  body {
+    @apply font-noto font-light;
+  }
   h1 {
     @apply text-4xl text-dekiru-font;
   }
@@ -63,15 +69,15 @@
 
 //************リンク**************//
 .blue-link {
-  @apply text-dekiru-blue text-sm hover:text-dekiru-light_blue font-bold
+  @apply text-dekiru-blue text-sm hover:text-dekiru-light_blue font-bold font-noto
 }
 
 .red-link {
-  @apply text-red-700 hover:text-red-300 text-sm
+  @apply text-red-700 hover:text-red-300 text-sm font-noto
 }
 
 .admin-link {
-  @apply text-dekiru-admin hover:text-pink-300 text-sm
+  @apply text-dekiru-admin hover:text-pink-300 text-sm font-noto
 }
 
 //************カード**************//

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -9,7 +9,7 @@
     @apply text-4xl text-dekiru-font;
   }
   h2 {
-    @apply text-2xl md:text-3xl text-dekiru-font font-medium;
+    @apply text-xl md:text-2xl text-dekiru-font font-medium;
   }
 }
 
@@ -140,6 +140,13 @@
   @apply my-2 text-sm text-left block max-w-4xl mx-auto opacity-70
 }
 
+
+//ズーム
+.zoom {
+  @apply transition duration-500 transform hover:scale-110
+}
+
+
 //************ movie **************//
 .movie__inner {
   position: relative;
@@ -215,3 +222,30 @@ iframe {
   top: 45%;
 }
 
+//************ page-top **************//
+#page-top {
+  position: fixed;
+  bottom: 10px;
+  right: 10px;
+  font-size: 77%;
+}
+#page-top a {
+  color: #fff;
+  width: 100px;
+  text-align: center;
+  display: block;
+}
+
+
+//トップページレイアウト
+.top-container {
+  @apply  my-8 max-w-6xl mx-auto bg-dekiru-base rounded p-4 m-4
+}
+
+.top-content-title {
+  @apply pt-4 border-b-2 md:border-none border-dekiru-blue pb-4 md:w-1/2 md:text-left
+}
+
+.top-link {
+  @apply pt-4 md:w-1/2 md:text-right md:mr-4
+}

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -19,9 +19,8 @@
  @apply text-white font-bold py-2 px-6 my-8 rounded-lg focus:outline-none shadow-lg
 }
 
-//背景色・hover時の背景色
 .blue-btn {
-  @apply base_btn bg-dekiru-blue hover:bg-dekiru-light_blue transition ease-in-out
+  @apply base_btn bg-gradient-to-r from-blue-400 to-dekiru-blue hover:from-dekiru-light_blue hover:to-dekiru-light_blue transition ease-out
 }
 
 .red-btn {
@@ -64,7 +63,7 @@
 
 //************リンク**************//
 .blue-link {
-  @apply text-dekiru-blue text-sm hover:text-dekiru-light_blue
+  @apply text-dekiru-blue text-sm hover:text-dekiru-light_blue font-bold
 }
 
 .red-link {

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -231,14 +231,12 @@ iframe {
 //************ page-top **************//
 #page-top {
   position: fixed;
-  bottom: 10px;
-  right: 10px;
+  bottom: 20px;
+  right: 20px;
   font-size: 77%;
 }
 #page-top a {
-  color: #fff;
-  width: 100px;
-  text-align: center;
+  width: 32px;
   display: block;
 }
 

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -15,7 +15,7 @@
     @apply text-4xl text-dekiru-font;
   }
   h2 {
-    @apply text-xl md:text-2xl text-dekiru-font font-medium;
+    @apply text-3xl md:text-4xl text-dekiru-font font-medium;
   }
 }
 
@@ -243,13 +243,17 @@ iframe {
 
 //トップページレイアウト
 .top-container {
-  @apply  my-8 max-w-6xl mx-auto bg-dekiru-base rounded p-4 m-4
+  @apply  my-8 max-w-6xl mx-auto p-4 m-4 
 }
 
 .top-content-title {
-  @apply pt-4 border-b-2 md:border-none border-dekiru-blue pb-4 md:w-1/2 md:text-left
+  @apply pt-4 border-b-2 border-dekiru-blue pb-4 md:w-1/2 md:text-left  md:flex
 }
 
 .top-link {
-  @apply pt-4 md:w-1/2 md:text-right md:mr-4
+  @apply pt-4 md:w-1/2 md:text-right md:mr-2 md:border-b-2 border-dekiru-blue
+}
+
+.top-blue-btn {
+ @apply  border-none px-4 py-2 text-xs bg-gray-100 text-dekiru-blue hover:bg-dekiru-blue hover:text-white
 }

--- a/app/javascript/stylesheets/tailwind.config.js
+++ b/app/javascript/stylesheets/tailwind.config.js
@@ -24,6 +24,9 @@ module.exports = {
           admin: '#FA198B',
         }
       },
+      fontFamily: {
+        noto: ['Noto Sans JP']
+      },      
     },
   },
   variants: {

--- a/app/views/categories/_category_card.html.erb
+++ b/app/views/categories/_category_card.html.erb
@@ -1,5 +1,5 @@
   <div class="p-3">
-    <%= link_to  category_path(category) do %>
+    <%= link_to category_path(category) do %>
       <span class="category-tag-btn"><%= category.name %></span>
     <% end %>
     

--- a/app/views/contents/_question_card.html.erb
+++ b/app/views/contents/_question_card.html.erb
@@ -41,7 +41,7 @@
         </div>
 
         <!-- 返信内容 -->
-        <div class="text-right px-4 py-8">
+        <div class="text-left px-4 py-8">
           <%= question.response.response_content %>
         </div>
 

--- a/app/views/contents/show.html.erb
+++ b/app/views/contents/show.html.erb
@@ -21,23 +21,26 @@
 
   <!-- 説明 -->
   <div>
-    <p class="text-lg py-4"><%= @content.title %></p>
+    <p class="text-2xl py-4 font-medium"><%= @content.title %></p>
     <p class="text-sm p-8"><%= @content. subtitle %></p>
     <p class="text-md p-8"><%= @content.comment %></p>
   </div>
 </div>
 
 <!-- タグ -->
-<div class="p-4 mb-8">
-  <h2 class="mb-4">タグ</h2>
-  <div>
-    <% @content.tag_masters.each do |tag| %>
-      <span class="content-tag-style">
-        <%= tag.tag_name %>
-      </span>
-    <% end %>
+<% if @content.tag_masters.present? %>
+  <div class="p-4 mb-8">
+    <h2 class="mb-4">タグ</h2>
+    <div>
+      <% @content.tag_masters.each do |tag| %>
+        <span class="content-tag-style">
+          <%= tag.tag_name %>
+        </span>
+      <% end %>
+    </div>
   </div>
-</div>
+<% end %>
+
 
 <!-- 材料 -->
 <div class="mb-8 border bg-dekiru-base">
@@ -67,7 +70,7 @@
 <!-- ポイント -->
 <div class="mb-8 pb-8 border bg-dekiru-base">
   <h2 class="py-8">ポイント</h2>
-  <p class="text-left p-8"><%= @content.point %></p>
+  <p class="p-8"><%= @content.point %></p>
 </div>
 
 <!-- review -->

--- a/app/views/contents/show.html.erb
+++ b/app/views/contents/show.html.erb
@@ -116,3 +116,6 @@
   </div>
 </div>
   
+
+<!--  TOPページボタン -->
+<%= render "layouts/page_top" %>

--- a/app/views/homes/index.html.erb
+++ b/app/views/homes/index.html.erb
@@ -7,12 +7,14 @@
 
 <!--  人気情報 -->
 <div class="top-container">
-  <div class="md:flex md:border-l-4 px-2 mx-4 border-dekiru-blue">
-    <h2 class="top-content-title">人気情報</h2>
-    <p class="top-link"><%= link_to ">>全て見る", popular_contents_path, class:"blue-link " %></p>
+  <div class="md:flex py-4">
+    <div class="borde top-content-title">
+      <h2>POPULAR</h2><span class="pt-2 block md:px-4 mt-2">人気情報</span>
+    </div>
+    <p class="top-link"><%= link_to ">>全て見る", popular_contents_path, class:"top-blue-btn" %></p>
   </div>
   
-  <div class="m-4 bg-dekiru-base rounded">
+  <div class="m-4">
     <div class="md:flex justify-center py-8 mb:py-16 ">
       <%= render partial: "layouts/top_page_content_card", collection: @popularity_contents, as: "content" %>
     </div>
@@ -22,12 +24,14 @@
 
 <!--  おすすめ情報 -->
 <div class="top-container">
-  <div class="md:flex md:border-l-4 px-2 mx-4 border-dekiru-blue">
-    <h2 class="top-content-title">おすすめ情報</h2>
-    <p class="top-link"><%= link_to ">>全て見る", recommend_contents_path, class:"blue-link" %></p>
+  <div class="md:flex py-4">
+    <div class="borde top-content-title">
+      <h2>RECOMMEND</h2><span class="pt-2 block md:px-4 mt-2">おすすめ</span>
+    </div>
+    <p class="top-link"><%= link_to ">>全て見る", recommend_contents_path, class:"top-blue-btn" %></p>
   </div>
 
-  <div class="m-4 bg-dekiru-base rounded">
+  <div class="m-4">
     <div class="md:flex justify-center py-8 mb:py-16">
       <%= render partial: "layouts/top_page_content_card", collection: @recommend_contents, as: "content" %>
     </div>
@@ -36,9 +40,11 @@
 
 <!--  新着情報 -->
 <div class="top-container">
-  <div class="md:flex md:border-l-4 px-2 mx-4 border-dekiru-blue">
-    <h2 class="top-content-title">新着情報</h2>
-    <p class="top-link"><%= link_to ">>全て見る", newest_contents_path, class:"blue-link" %></p>
+  <div class="md:flex py-4 ">
+    <div class="borde top-content-title">
+      <h2>NEWEST</h2><span class="pt-2 block md:px-4 mt-2">新着情報</span>
+    </div>
+    <p class="top-link"><%= link_to ">>全て見る", newest_contents_path, class:"top-blue-btn" %></p>
   </div>
 
   <div class="md:flex justify-center py-8 mb:py-16">
@@ -47,10 +53,12 @@
 </div>
 
 <!--  カテゴリー -->
-<div class="my-8 max-w-6xl mx-auto bg-dekiru-base rounded p-4">
-  <div class="md:flex md:border-l-4 px-2 mx-4 border-dekiru-blue">
-    <h2 class="top-content-title">カテゴリー一覧</h2>
-    <p class="top-link"><%= link_to ">>全て見る", categories_path, class:"blue-link" %></p>
+<div class="my-8 max-w-6xl mx-auto p-4">
+  <div class="md:flex py-4">
+    <div class="borde top-content-title">
+      <h2>CATEGORY</h2><span class="pt-2 block md:px-4 mt-2">カテゴリー</span>
+    </div>
+    <p class="top-link"><%= link_to ">>全て見る", categories_path, class:"top-blue-btn" %></p>
   </div>
    <div class="py-8 mb:py-16">
     <%= render partial: "layouts/category_contents_card", collection: @categories, as: "category" %>
@@ -59,8 +67,10 @@
 
 <!--  キーワード -->
 <div class="top-container">
-  <div class="md:flex md:border-l-4 px-2 mx-4 border-dekiru-blue">
-    <h2 class="top-content-title">キーワード</h2>
+  <div class="md:flex py-4">
+    <div class="borde top-content-title">
+      <h2>KEYWORD</h2><span class="pt-2 block md:px-4 mt-2">キーワード</span>
+    </div>
     <p class="top-link"><%#= link_to ">>全て見る", categories_path, class:"blue-link" %></p><%# TODO: 数が多くなった場合実装する%>
   </div>
 

--- a/app/views/homes/index.html.erb
+++ b/app/views/homes/index.html.erb
@@ -68,9 +68,13 @@
     <%= render partial: "layouts/content_tag", collection: @content_tags, as: "tag" %>
   </div>
 
-<!--  TOPページボタン -->
-<p id="page-top">
-  <a href="#wrap" class="bg-dekiru-blue text-white hover:bg-dekiru-light_blue no-underline rounded-full py-10">TOP</a>
-</p>
+  <!--  TOPページボタン -->
+  <p id="page-top">
+    <a href="#wrap" class="text-dekiru-blue  no-underline py-4 mx-auto">
+      <svg xmlns="http://www.w3.org/2000/svg" class="h-10 w-10" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-8.707l-3-3a1 1 0 00-1.414 0l-3 3a1 1 0 001.414 1.414L9 9.414V13a1 1 0 102 0V9.414l1.293 1.293a1 1 0 001.414-1.414z" clip-rule="evenodd" />
+      </svg>
+    </a>
+  </p>
 
 </div>

--- a/app/views/homes/index.html.erb
+++ b/app/views/homes/index.html.erb
@@ -69,12 +69,6 @@
   </div>
 
   <!--  TOPページボタン -->
-  <p id="page-top">
-    <a href="#wrap" class="text-dekiru-blue  no-underline py-4 mx-auto">
-      <svg xmlns="http://www.w3.org/2000/svg" class="h-10 w-10" viewBox="0 0 20 20" fill="currentColor">
-      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-8.707l-3-3a1 1 0 00-1.414 0l-3 3a1 1 0 001.414 1.414L9 9.414V13a1 1 0 102 0V9.414l1.293 1.293a1 1 0 001.414-1.414z" clip-rule="evenodd" />
-      </svg>
-    </a>
-  </p>
+  <%= render "layouts/page_top" %>
 
 </div>

--- a/app/views/homes/index.html.erb
+++ b/app/views/homes/index.html.erb
@@ -1,5 +1,5 @@
 <!-- トップ画像 -->
-<div class="mt-8 mb-16">
+<div class="mb-16">
   <div class="max-w-6xl mx-auto">
     <%= image_tag "dekiru-top-image.png"%>
   </div>

--- a/app/views/homes/index.html.erb
+++ b/app/views/homes/index.html.erb
@@ -6,59 +6,71 @@
 </div>
 
 <!--  人気情報 -->
-<div class="my-8 max-w-6xl mx-auto">
+<div class="top-container">
   <div class="md:flex md:border-l-4 px-2 mx-4 border-dekiru-blue">
-      <h2 class="pt-4 border-b-2 md:border-none border-dekiru-blue pb-4 md:w-1/2 md:text-left">人気情報</h2>
-      <p class="pt-4 md:w-1/2 md:text-right md:mr-4"><%= link_to ">>全て見る", popular_contents_path, class:"blue-link" %></p>
+    <h2 class="top-content-title">人気情報</h2>
+    <p class="top-link"><%= link_to ">>全て見る", popular_contents_path, class:"blue-link " %></p>
   </div>
   
-  <div class="md:flex justify-center py-8 mb:py-16">
-    <%= render partial: "layouts/top_page_content_card", collection: @popularity_contents, as: "content" %>
+  <div class="m-4 bg-dekiru-base rounded">
+    <div class="md:flex justify-center py-8 mb:py-16 ">
+      <%= render partial: "layouts/top_page_content_card", collection: @popularity_contents, as: "content" %>
+    </div>
   </div>
 </div>
 
+
 <!--  おすすめ情報 -->
-<div class="my-8 max-w-6xl mx-auto">   
+<div class="top-container">
   <div class="md:flex md:border-l-4 px-2 mx-4 border-dekiru-blue">
-    <h2 class="pt-4 border-b-2 md:border-none border-dekiru-blue pb-4 md:w-1/2 md:text-left">おすすめ情報</h2>
-    <p class="pt-4 md:w-1/2 md:text-right md:mr-4"><%= link_to ">>全て見る", recommend_contents_path, class:"blue-link" %></p>
+    <h2 class="top-content-title">おすすめ情報</h2>
+    <p class="top-link"><%= link_to ">>全て見る", recommend_contents_path, class:"blue-link" %></p>
   </div>
-  <div class="md:flex justify-center py-8 mb:py-16">
-    <%= render partial: "layouts/top_page_content_card", collection: @recommend_contents, as: "content" %>
+
+  <div class="m-4 bg-dekiru-base rounded">
+    <div class="md:flex justify-center py-8 mb:py-16">
+      <%= render partial: "layouts/top_page_content_card", collection: @recommend_contents, as: "content" %>
+    </div>
   </div>
 </div>
 
 <!--  新着情報 -->
-<div class="my-8 max-w-6xl mx-auto">
+<div class="top-container">
   <div class="md:flex md:border-l-4 px-2 mx-4 border-dekiru-blue">
-    <h2 class="pt-4 border-b-2 md:border-none border-dekiru-blue pb-4 md:w-1/2 md:text-left">新着情報</h2>
-    <p class="pt-4 md:w-1/2 md:text-right md:mr-4"><%= link_to ">>全て見る", newest_contents_path, class:"blue-link" %></p>
+    <h2 class="top-content-title">新着情報</h2>
+    <p class="top-link"><%= link_to ">>全て見る", newest_contents_path, class:"blue-link" %></p>
   </div>
+
   <div class="md:flex justify-center py-8 mb:py-16">
     <%= render partial: "layouts/top_page_content_card", collection: @new_contents, as: "content" %>
   </div>
 </div>
 
 <!--  カテゴリー -->
-<div class="my-8 max-w-6xl mx-auto">
+<div class="my-8 max-w-6xl mx-auto bg-dekiru-base rounded p-4">
   <div class="md:flex md:border-l-4 px-2 mx-4 border-dekiru-blue">
-    <h2 class="pt-4 border-b-2 md:border-none border-dekiru-blue pb-4 md:w-1/2 md:text-left">カテゴリー一覧</h2>
-    <p class="pt-4 md:w-1/2 md:text-right md:mr-4"><%= link_to ">>全て見る", categories_path, class:"blue-link" %></p>
+    <h2 class="top-content-title">カテゴリー一覧</h2>
+    <p class="top-link"><%= link_to ">>全て見る", categories_path, class:"blue-link" %></p>
   </div>
    <div class="py-8 mb:py-16">
     <%= render partial: "layouts/category_contents_card", collection: @categories, as: "category" %>
   </div>
 </div>
 
-<div class="my-8 max-w-6xl mx-auto">
-  
-    <div class="md:flex md:border-l-4 px-2 mx-4 border-dekiru-blue">
-    <h2 class="pt-4 border-b-2 md:border-none border-dekiru-blue pb-4 md:w-1/2 md:text-left">キーワード</h2>
-    <p class="pt-4 md:w-1/2 md:text-right md:mr-4"><%#= link_to ">>全て見る", categories_path, class:"blue-link" %></p><%# TODO: 数が多くなった場合実装する%>
+<!--  キーワード -->
+<div class="top-container">
+  <div class="md:flex md:border-l-4 px-2 mx-4 border-dekiru-blue">
+    <h2 class="top-content-title">キーワード</h2>
+    <p class="top-link"><%#= link_to ">>全て見る", categories_path, class:"blue-link" %></p><%# TODO: 数が多くなった場合実装する%>
   </div>
 
   <div class="flex justify-center md:justify-start flex-wrap my-1 max-w-6xl px-4"> 
     <%= render partial: "layouts/content_tag", collection: @content_tags, as: "tag" %>
   </div>
+
+<!--  TOPページボタン -->
+<p id="page-top">
+  <a href="#wrap" class="bg-dekiru-blue text-white hover:bg-dekiru-light_blue no-underline rounded-full py-10">TOP</a>
+</p>
 
 </div>

--- a/app/views/layouts/_category_contents_card.html.erb
+++ b/app/views/layouts/_category_contents_card.html.erb
@@ -1,7 +1,7 @@
 <div class="py-8 bg-dekiru-base m-4">
   <div class="md:flex md:border-l-4 px-2 mx-4 border-dekiru-blue">
     <p class=" md:border-none border-dekiru-blue md:w-1/2 md:text-left"><%= category.name %></p>
-    <p class="md:w-1/2 md:text-right md:mr-4"><%= link_to ">>このカテゴリーへ移動", category_path(category.id), class:"blue-link" %></p>
+    <p class="md:w-1/2 md:text-right"><%= link_to ">>このカテゴリーへ移動", category_path(category.id), class:"blue-link" %></p>
  　</div>
   <div class="flex">
     <%= render partial: "layouts/top_page_content_card", collection: category.contents.published.first(2), as: "content" %>

--- a/app/views/layouts/_content_card.html.erb
+++ b/app/views/layouts/_content_card.html.erb
@@ -1,4 +1,4 @@
-<div class="md:w-1/2 xl:w-1/3">
+<div class="md:w-1/2 xl:w-1/3 zoom">
 <%= link_to content_show_path(content.id) do %>
   <div class="max-w-2xl m-2 overflow-hidden bg-white rounded shadow-lg">
     <div><%= image_tag youtube_thumbnail(content.movie_id), class:"w-full object-cover" %></div>

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -13,13 +13,17 @@
 
     <!-- 各種リンク -->
     <ul class="p-4 text-dekiru-font md:w-1/2 md:text-right">
-      <li class="mb-8 md:mb-4"><%= link_to "トップ", root_path, class:"text-whitehover:text-dekiru-blue" %></li>
+      <li class="mb-8 md:mb-4"><%= link_to "トップ", root_path, class:"hover:text-dekiru-blue" %></li>
       <li class="mb-8 md:mb-4"><%= link_to "カテゴリー一覧", categories_path, class:"hover:text-dekiru-blue" %></li>
       <% if user_signed_in? %>
         <li class="mb-8 md:mb-4"><%= link_to "マイページ", mypage_path(current_user), class:"hover:text-dekiru-blue" %></li>
         <li class="mb-8"><%= link_to "お問い合わせ", contacts_path, class:"hover:text-dekiru-blue" %></li>
       <% end %>
     </ul>
+  </div>
+
+  <div class="py-4">
+    ©2021 deKiru
   </div>
 
 </footer>

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -1,4 +1,4 @@
-<footer class="bg-dekiru-base py-8 text-center border">
+<footer class="bg-dekiru-light_blue py-8 text-center border">
 
   <div class="p-4 md:flex md:mx-20 xl:mx-60">
 
@@ -13,7 +13,7 @@
 
     <!-- 各種リンク -->
     <ul class="p-4 text-dekiru-font md:w-1/2 md:text-right">
-      <li class="mb-8 md:mb-4"><%= link_to "トップ", root_path, class:"hover:text-dekiru-blue" %></li>
+      <li class="mb-8 md:mb-4"><%= link_to "トップ", root_path, class:"text-whitehover:text-dekiru-blue" %></li>
       <li class="mb-8 md:mb-4"><%= link_to "カテゴリー一覧", categories_path, class:"hover:text-dekiru-blue" %></li>
       <% if user_signed_in? %>
         <li class="mb-8 md:mb-4"><%= link_to "マイページ", mypage_path(current_user), class:"hover:text-dekiru-blue" %></li>

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -20,8 +20,6 @@
         <li class="mb-8"><%= link_to "お問い合わせ", contacts_path, class:"hover:text-dekiru-blue" %></li>
       <% end %>
     </ul>
-
-
   </div>
 
 </footer>

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -1,4 +1,4 @@
-<footer class="bg-dekiru-light_blue py-8 text-center border">
+<footer class="bg-dekiru-light_blue py-8 text-center">
 
   <div class="p-4 md:flex md:mx-20 xl:mx-60">
 

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,4 +1,4 @@
-<header class="sticky top-0 z-10 p-1 text-center bg-dekiru-base shadow-sm">
+<header class="sticky top-0 z-10 p-1 text-center bg-dekiru-light_blue shadow-2xd">
   <div class="mx-4 md:mx-20 xl:mx-60 py-4 flex text-center justify-center items-center">
 
     <!-- ロゴ -->

--- a/app/views/layouts/_page_top.html.erb
+++ b/app/views/layouts/_page_top.html.erb
@@ -1,0 +1,8 @@
+  <!--  TOPページボタン -->
+  <p id="page-top">
+    <a href="#wrap" class="text-dekiru-blue  no-underline py-4 mx-auto">
+      <svg xmlns="http://www.w3.org/2000/svg" class="h-10 w-10" viewBox="0 0 20 20" fill="currentColor">
+      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-8.707l-3-3a1 1 0 00-1.414 0l-3 3a1 1 0 001.414 1.414L9 9.414V13a1 1 0 102 0V9.414l1.293 1.293a1 1 0 001.414-1.414z" clip-rule="evenodd" />
+      </svg>
+    </a>
+  </p>

--- a/app/views/layouts/_search_form.html.erb
+++ b/app/views/layouts/_search_form.html.erb
@@ -1,8 +1,8 @@
 <!-- 検索フォーム -->
 <div>
   <%= search_form_for @q, url: search_contents_path do |f| %>
-    <%= f.search_field :title_or_subtitle_or_comment_or_tag_masters_tag_name_cont, placeholder:"キーワードを入力", class:"text-filed bg-gray-200 rounded-full p-2 focus:outline-none" %>
+    <%= f.search_field :title_or_subtitle_or_comment_or_tag_masters_tag_name_cont, placeholder:"キーワードを入力", class:"text-filed bg-white rounded-full p-2 focus:outline-none" %>
     <%# これをアイコンにする%>
-    <%= f.submit class: "bg-dekiru-base"%>
+    <%= f.submit class: "bg-dekiru-light_blue"%>
   <% end %>
 </div>

--- a/app/views/layouts/_top_page_content_card.html.erb
+++ b/app/views/layouts/_top_page_content_card.html.erb
@@ -1,4 +1,4 @@
-<div class="md:w-1/2">
+<div class="md:w-1/2 zoom">
 <%= link_to content_show_path(content.id) do %>
   <div class="w-11/12 2xl:w-full my-4 max-w-lg mx-auto shadow-x1 overflow-hidden bg-white rounded shadow-lg">
     <%= image_tag youtube_thumbnail(content.movie_id), class:"w-full object-cover" %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,8 +8,8 @@
     <%= stylesheet_pack_tag "application", "data-turbo-track": "reload" %>
   </head>
   <body>
-    <%= render "layouts/flash" %>
     <%= render "layouts/header" %>
+    <%= render "layouts/flash" %>
     <div class="text-center mx-4 md:mx-4 xl:mx-48">
       <%= yield %>
     </div>


### PR DESCRIPTION
## 実装の目的と概要
- レイアウトを修正
## 実装内容(技術的な点を記載)
- webフォントの実装
- トップページのレイアウトを調整
- トップへ戻るボタンの実装
- コンテンツにhoverした時、少し拡大する動作を実装
- コピーライトの実装
- header,footerの色を変更

## スクリーンショット（画面レイアウトを変更した場合）
<img width="1680" alt="スクリーンショット 2021-06-15 12 13 13" src="https://user-images.githubusercontent.com/64491435/121987572-b4338180-cdd3-11eb-9d2f-7ea2171c2c86.png">
<img width="1680" alt="スクリーンショット 2021-06-15 12 13 31" src="https://user-images.githubusercontent.com/64491435/121987581-b8f83580-cdd3-11eb-9865-4eb20501dca7.png">



## 参考資料
- [Scale](https://tailwindcss.com/docs/scale)
- [Noto Sans JP](https://fonts.google.com/specimen/Noto+Sans+JP#standard-styles)
- [jQueryでスクロールすると表示する系いろいろ](https://www.webopixel.net/javascript/538.html)
## チェックリスト

- [x] ローカル環境での動作確認をしたか（影響し得る範囲も含めて）
- [x] rubocopを実行して警告が出力されていないか
- [x] GitHub で ファイル差分（Files changed）を確認し、内容が合っているか。不要なファイルに差分がでていないか
- [x] テストでエラーが発生していないか