### PR TITLE
[改善]ハンバーガーメニューを修正

### DIFF
--- a/app/views/layouts/_sp_header.html.erb
+++ b/app/views/layouts/_sp_header.html.erb
@@ -17,10 +17,11 @@
             <li class="hover:bg-dekiru-blue"><%= link_to "トップ", root_path , class:"hover:text-white"%></li>
             <% if user_signed_in? %>
               <li class="hover:bg-dekiru-blue"><%= link_to "マイページ", mypage_path(current_user), class:"hover:text-white" %></li><%# ログイン時 %>
+              <li class="hover:bg-dekiru-blue"><%= link_to "お気に入り一覧", favorite_contents_path, class:"hover:text-white" %></li>
+             <li class="hover:bg-dekiru-blue"><%= link_to "ログアウト", destroy_user_session_path, method: :delete, class:"hover:text-white"%></li><%# 非ログイン時 %>
            <% else %>
              <li class="hover:bg-dekiru-blue"><%= link_to "ログイン", new_user_session_path , class:"hover:text-white"%></li><%# 非ログイン時 %>
            <% end %>   
-            <li class="hover:bg-dekiru-blue"><%= link_to "お気に入り一覧", favorite_contents_path, class:"hover:text-white" %></li>
           </ul>
         </div>
       </div>


### PR DESCRIPTION
## 実装の目的と概要
- ハンバーガーメニューにログイン時に表示されるべきリンクが表示されていたため、修正

## 実装内容(技術的な点を記載)
- ハンバーガーメニューの修正

## スクリーンショット（画面レイアウトを変更した場合）
<img width="503" alt="スクリーンショット 2021-06-21 15 55 27" src="https://user-images.githubusercontent.com/64491435/122719649-72aa4700-d2a9-11eb-9084-31df034bc1d0.png">
<img width="503" alt="スクリーンショット 2021-06-21 15 55 35" src="https://user-images.githubusercontent.com/64491435/122719655-750ca100-d2a9-11eb-893a-0d4bb1e0a637.png">

## チェックリスト

- [x] ローカル環境での動作確認をしたか（影響し得る範囲も含めて）
- [x] rubocopを実行して警告が出力されていないか
- [x] GitHub で ファイル差分（Files changed）を確認し、内容が合っているか。不要なファイルに差分がでていないか
- [ ] テストでエラーが発生していないか