### PR TITLE
[改善]非公開のコンテンツの表示を制限する

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -21,6 +21,13 @@ class ApplicationController < ActionController::Base
     redirect_to root_path, alert: "管理者はこの操作を行うことができません" and return unless current_user.general? # ログインユーザーが一般ユーザーか
   end
 
+   # 管理者判定
+  def admin_user?
+    if user_signed_in?
+      current_user.user_type == "admin"
+    end
+  end
+
   private
 
     def configure_permitted_parameters

--- a/app/controllers/contents_controller.rb
+++ b/app/controllers/contents_controller.rb
@@ -20,8 +20,9 @@ class ContentsController < ApplicationController
 
   def show
     # 非公開の場合の処理
-    return unless @content.non_published?
-    redirect_to root_path, alert: "大変申し訳ありません。ただいまこのコンテンツは調整中です。" and return unless admin_user?
+    if @content.non_published? && !admin_user?
+      redirect_to root_path, alert: "大変申し訳ありません。ただいまこのコンテンツは調整中です。" and return
+    end
 
     @makes = @content.makes
     @materials = @content.materials

--- a/app/controllers/contents_controller.rb
+++ b/app/controllers/contents_controller.rb
@@ -19,6 +19,10 @@ class ContentsController < ApplicationController
   end
 
   def show
+    # 非公開の場合の処理
+    return unless @content.non_published?
+    redirect_to root_path, alert: "大変申し訳ありません。ただいまこのコンテンツは調整中です。" and return unless admin_user?
+
     @makes = @content.makes
     @materials = @content.materials
     @reviews = @content.reviews.includes(:user)

--- a/spec/factories/contents.rb
+++ b/spec/factories/contents.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :content do
-    # association :category, factory: :category
+    association :category, factory: :category
     title { Faker::Lorem.characters(number: 16) }
     subtitle { Faker::Lorem.characters(number: 32) }
     movie_url { "https://www.youtube.com/watch?v=Otrc2zAlJyM" }

--- a/spec/features/contents_spec.rb
+++ b/spec/features/contents_spec.rb
@@ -153,7 +153,7 @@ RSpec.describe "Contents", type: :feature do
     end
 
     context "材料が存在する時" do
-      it "リンクが表示される" do
+      it "リンクが表示される", type: :do do
         sign_in @admin
         visit content_show_path(@content.id)
         expect(page).to have_link ">>編集", href: edit_material_path(@material.id, params: { content_id: @material.content.id })


### PR DESCRIPTION
## 実装の目的と概要
- `content/show`を`admin`のみ閲覧できるようにする

## 実装内容(技術的な点を記載)
- `content/show`を`admin`のみに制限
- テストを修正

## 参考資料

## チェックリスト

- [x] ローカル環境での動作確認をしたか（影響し得る範囲も含めて）
- [x] rubocopを実行して警告が出力されていないか
- [x] GitHub で ファイル差分（Files changed）を確認し、内容が合っているか。不要なファイルに差分がでていないか
- [x] テストでエラーが発生していないか
