### PR TITLE
[改善]Userのログイン機能を修正

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -11,7 +11,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
   protected
 
-    # 必須  更新（編集の反映）時にパスワード入力を省く
+    # 更新時にパスワード入力を省略
     def update_resource(resource, params)
       resource.update_without_password(params)
     end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -11,7 +11,12 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
   protected
 
-     # アカウント編集後のリダイレクト先
+    # 必須  更新（編集の反映）時にパスワード入力を省く
+    def update_resource(resource, params)
+      resource.update_without_password(params)
+    end
+
+    # アカウント編集後のリダイレクト先
     def after_update_path_for(resource)
       mypage_path(current_user)
     end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 class Users::RegistrationsController < Devise::RegistrationsController
-  before_action :ensure_normal_user, only: %i[destroy] # rubocop:disable all
+  before_action :ensure_normal_user, only: %i[edit destroy] # rubocop:disable all
 
   def ensure_normal_user
     if resource.email == "guest@example.com"
-      redirect_to root_path, alert: "ゲストユーザーの更新・削除はできません。"
+      redirect_to mypage_path(current_user), notice: "ゲストユーザーの更新・削除はできません。"
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,7 +10,7 @@ class User < ApplicationRecord
 
   # バリデージョン
   VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i.freeze
-  validates :name, presence: true, length: { in: 1..10, allow_blank: true }, uniqueness: { case_sensitive: true }
+  validates :name, presence: true, length: { in: 1..16, allow_blank: true }, uniqueness: { case_sensitive: true }
   validates :email, presence: true, format: { with: VALID_EMAIL_REGEX }, uniqueness: { case_sensitive: true }
   validates :password, length: { in: 8..16, allow_blank: true },
                        format: { with: /\A[a-zA-Z\d@\-_]+\z/, allow_blank: true,

--- a/app/views/users/registrations/edit.html.erb
+++ b/app/views/users/registrations/edit.html.erb
@@ -43,11 +43,6 @@
         <%= f.password_field :password_confirmation, autocomplete: "new-password",placeholder: "例：pass2021", maxlength:"16", class: "text-field" %>
       </div>
 
-      <div class="field">
-        <div class="form-title">現在のパスワード<span class="required_content">必須</span></div>
-        <%= f.password_field :current_password, autocomplete: "current-password", placeholder: "現在のパスワード", maxlength:"16",required: true, class: "text-field" %>
-      </div>
-
       <div class="actions">
         <%= f.submit "確定する",data: { confirm: '確定します。よろしいでしょうか？', disable_with: "送信中..." }, class:"submit-btn" %>
       </div>

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -9,7 +9,7 @@
   
     <div class="field">
       <div class="form-title">ユーザー名<span class="required_content">必須</span></div>
-      <%= f.text_field :name, placeholder: "名前入力(16文字以内)", required: true, maxlength:"16", class: "text-field"%>
+      <%= f.text_field :name, placeholder: "名前入力(16文字以内)", required: true, autofocus: true, maxlength:"16", class: "text-field"%>
     </div>
   
     <div class="field">

--- a/spec/features/contents_spec.rb
+++ b/spec/features/contents_spec.rb
@@ -153,7 +153,7 @@ RSpec.describe "Contents", type: :feature do
     end
 
     context "材料が存在する時" do
-      it "リンクが表示される", type: :do do
+      it "リンクが表示される" do
         sign_in @admin
         visit content_show_path(@content.id)
         expect(page).to have_link ">>編集", href: edit_material_path(@material.id, params: { content_id: @material.content.id })

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -11,6 +11,42 @@ RSpec.describe User, type: :model do
       end
     end
 
+    describe "name" do
+      context "入力さていない時" do
+        let(:user) { build(:user, name: "") }
+        it "保存ができない" do
+          expect(subject).to eq false
+          expect(user.errors[:name]).to include "を入力してください"
+        end
+      end
+
+      context "16文字の場合" do
+        let(:user) { build(:user, name: "1" * 16) }
+        it "保存できる" do
+          expect(subject).to eq true
+        end
+      end
+
+      context "17文字の場合" do
+        let(:user) { build(:user, name: "1" * 17) }
+
+        it "保存ができない" do
+          expect(subject).to eq false
+          expect(user.errors.messages[:name]).to include "は16文字以内で入力してください"
+        end
+      end
+
+      context "他のユーザと重複している時" do
+        before { create(:user, name: "名前") }
+
+        let(:user) { build(:user, name: "名前") }
+        it "保存ができない" do
+          expect(subject).to eq false
+          expect(user.errors.messages[:name]).to include "はすでに存在します"
+        end
+      end
+    end
+
     describe "email" do
       context "入力さていない時" do
         let(:user) { build(:user, email: "") }


### PR DESCRIPTION
## 実装の目的と概要
- ユーザー編集時、パスワードを要求するのは冗長のため、排除する
- バリデージョン のミスに対応する

## 実装内容(技術的な点を記載)
- [x] ユーザー編集時にパスワードの要求を排除
- [x] ゲストユーザーの編集を不可
- [x] 画面遷移時のフォーカスを修正
- [x] バリデージョンのミスを修正
- [x] Userのモデルスペックを追加
 

## スクリーンショット（画面レイアウトを変更した場合）
<img width="1680" alt="スクリーンショット 2021-06-29 10 14 19" src="https://user-images.githubusercontent.com/64491435/123724228-f0340f80-d8c6-11eb-98d1-1d4a11b5eeaa.png">
<img width="1680" alt="スクリーンショット 2021-06-29 10 13 54" src="https://user-images.githubusercontent.com/64491435/123724141-c67ae880-d8c6-11eb-83a5-89bf7ee2a97a.png">
<img width="838" alt="スクリーンショット 2021-06-29 10 33 35" src="https://user-images.githubusercontent.com/64491435/123724144-c7137f00-d8c6-11eb-8b74-2e80347eed18.png">


## 参考資料
- [[devise]パスワード入力不要のユーザー編集](https://qiita.com/1992_momotaro/items/d8a220be528a7af69deb)
- [autofocus 属性で初期フォーカス位置を設定する](https://maku77.github.io/web/form/autofocus.html)
## チェックリスト

- [x] ローカル環境での動作確認をしたか（影響し得る範囲も含めて）
- [x] rubocopを実行して警告が出力されていないか
- [x] GitHub で ファイル差分（Files changed）を確認し、内容が合っているか。不要なファイルに差分がでていないか
- [x] テストでエラーが発生していないか