### PR TITLE
[改善]文言にリンクを実装

### DIFF
--- a/app/controllers/homes_controller.rb
+++ b/app/controllers/homes_controller.rb
@@ -5,6 +5,6 @@ class HomesController < ApplicationController
     @new_contents = Content.published.order(created_at: :desc).first(TOP_PAGE_CONTENT)
     @categories = Category.order("RAND()").first(TOP_PAGE_CONTENT)
     @category_names = Category.order(created_at: :desc)
-    @content_tags = TagMaster.order("RAND()")
+    @content_tags = TagMaster.content.order("RAND()")
   end
 end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -8,7 +8,8 @@ class Users::SessionsController < Devise::SessionsController
   def guest_sign_in
     sign_in User.guest
     User.create_sample_date
-    redirect_to root_path, notice: "ゲストユーザーとしてログインしました。「レビュー」「質問」「お気に入り」「お問い合わせ」が実施できます"
+    flash[:gest_login] = "ゲストユーザーとしてログインしました。「レビュー」「質問」「お気に入り」が実施できます"
+    redirect_to root_path
   end
 
   protected

--- a/app/views/contacts/_confirm_fields.html.erb
+++ b/app/views/contacts/_confirm_fields.html.erb
@@ -1,4 +1,4 @@
-　<div class="border">
+　<div>
 
 　  <p>以下の内容で送信します。よろしいでしょうか？</p>
 　  <!-- ログインユーザーでない場合、以下を表示する-->
@@ -15,7 +15,6 @@
 　    </div>
 　  <% end %>
 　  <!-- ログインユーザーでない場合、以上を表示する-->
-
 　  <div>
 　    <span><%= form.label :title, class:"form-title" %></span>
 　    <%= form.text_field :title, readonly: true, class: "text-field" %>

--- a/app/views/contacts/new.html.erb
+++ b/app/views/contacts/new.html.erb
@@ -5,6 +5,7 @@
 <div class="py-8">
 
   <h1 class="h1">お問い合わせ<%= " 《確認》" if @contact.submitted == "1" %></h1>
+  <p><%= "お問い合わせ・リクエストはこちらからお願いいたします。" if @contact.submitted == nil %></p>
   
   <div class="pb-8">
     <%= form_with model: @contact, local: true do |form| %>
@@ -20,7 +21,8 @@
             <div class="mt-4"><%= form.button "戻る", name: "contact[confirmed]", value: "", class:"submit-btn" %></div>
             <div><%= form.button "送信", name: "contact[confirmed]", value: "1", data: { disable_with: "送信中..." }, class:"submit-btn" %></div>
           </div>
-            <% else %>
+
+        <% else %>
           <%# 投稿画面 %>
           <%= render "submit_fields", form: form %>
           <div class="py-8"><%= form.submit "確認", class:"submit-btn" %></div>

--- a/app/views/contents/search.html.erb
+++ b/app/views/contents/search.html.erb
@@ -49,7 +49,7 @@
     </div>
   <% else %>
     <p>検索結果はありません</p>
-    <%# TODO: リクエストやお問い合わせができるようにする%>
+    <p class="p-4"><%= link_to "> リクエストはこちら！", new_contact_path, class:"text-dekiru-blue font-black hover:text-dekiru-light_blue"%></p>
   <% end %>
   
   <!-- ページネーション  -->

--- a/app/views/contents/show.html.erb
+++ b/app/views/contents/show.html.erb
@@ -118,7 +118,10 @@
         <p>管理者は質問できません。</p>
       <% end %>
     <% else %>
-      <p>ログインすると、質問ができます</p>
+      <p class="py-4">
+        <span><%= link_to "「ログイン」", new_user_session_path , class:"blue-link"%></span>
+        すると、質問ができます
+      </p>
     <% end %>
   </div>
 </div>

--- a/app/views/layouts/_flash.html.erb
+++ b/app/views/layouts/_flash.html.erb
@@ -1,5 +1,6 @@
 <% flash.each do |flash_type, msg| %>
-  <% if flash_type == "notice" %>
+  <% case flash_type
+    when "notice" %>
     <!-- 青色の通知-->
     <div class="flex flex-col space-y-3 p-3">
       <div class="bg-dekiru-light_blue p-5 w-full  border-l-4 border-dekiru-blue">
@@ -12,7 +13,8 @@
         </div>
       </div>
     </div>
-  <% elsif flash_type == "alert" %>
+
+  <% when "alert" %>
     <!-- 赤色の通知-->
     <div class="flex flex-col space-y-3 p-3">
       <div class="bg-red-100 p-5 w-full border-l-4 border-red-700">
@@ -20,6 +22,20 @@
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="flex-none fill-current text-red-500 h-4 w-4">
         <path d="M12 0c-6.627 0-12 5.373-12 12s5.373 12 12 12 12-5.373 12-12-5.373-12-12-12zm4.597 17.954l-4.591-4.55-4.555 4.596-1.405-1.405 4.547-4.592-4.593-4.552 1.405-1.405 4.588 4.543 4.545-4.589 1.416 1.403-4.546 4.587 4.592 4.548-1.403 1.416z" /></svg>
           <div class="flex-1 leading-tight text-sm text-red-700">
+            <p><%= msg %><p>
+          </div>
+        </div>
+      </div>
+    </div>
+
+  <% when "gest_login" %>
+    <!-- ゲストログインの通知 文言を変更する場合に備えて実装 -->
+    <div class="flex flex-col space-y-3 p-3">
+      <div class="bg-dekiru-light_blue p-5 w-full  border-l-4 border-dekiru-blue">
+        <div class="flex space-x-3">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="flex-none fill-current text-blue-500 h-4 w-4">
+          <path d="M12 0c-6.627 0-12 5.373-12 12s5.373 12 12 12 12-5.373 12-12-5.373-12-12-12zm-.001 5.75c.69 0 1.251.56 1.251 1.25s-.561 1.25-1.251 1.25-1.249-.56-1.249-1.25.559-1.25 1.249-1.25zm2.001 12.25h-4v-1c.484-.179 1-.201 1-.735v-4.467c0-.534-.516-.618-1-.797v-1h3v6.265c0 .535.517.558 1 .735v.999z" /></svg>
+          <div class="flex-1 leading-tight text-sm text-blue-700">
             <p><%= msg %><p>
           </div>
         </div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -35,6 +35,8 @@ ja:
       tag_master: 
         tag_name: キーワード名
       contact:
+        name: お名前
+        email: メールアドレス
         title: お問い合わせタイトル
         content: お問い合わせ内容
     models:


### PR DESCRIPTION
##  実装内容(技術的な点を記載)
- 文言にログインリンクを追加
- フラッシュメッセージの修正
- 検索結果がない場合、リクエストリンクを表示
- 使用されていないタグを表示させない

 
## スクリーンショット（画面レイアウトを変更した場合）
<img width="838" alt="スクリーンショット 2021-06-29 16 18 08" src="https://user-images.githubusercontent.com/64491435/123762619-f1ccfa00-d8fd-11eb-80fb-f93ddee8628d.png">
<img width="838" alt="スクリーンショット 2021-06-29 12 31 35" src="https://user-images.githubusercontent.com/64491435/123762794-1923c700-d8fe-11eb-9551-16f3ad1faf74.png">

## チェックリスト

- [x] ローカル環境での動作確認をしたか（影響し得る範囲も含めて）
- [x] rubocopを実行して警告が出力されていないか
- [x] GitHub で ファイル差分（Files changed）を確認し、内容が合っているか。不要なファイルに差分がでていないか
- [x] テストでエラーが発生していないか
