### PR TITLE
[改善]TOP画像を小さくする/404にレイアウトを実装

### DIFF
--- a/app/views/homes/_main_content.html.erb
+++ b/app/views/homes/_main_content.html.erb
@@ -1,10 +1,9 @@
 <!-- トップ画像 -->
-<div class="mb-16">
+<div class="m-20 xl:m-32">
   <div class="max-w-6xl mx-auto">
     <%= image_tag "dekiru-top-image.png"%>
   </div>
 </div>
-
 
 <!--  人気情報 -->
 <div class="top-container">

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -20,7 +20,7 @@ Rails.application.configure do
   config.eager_load = false
 
   # 本番環境のみ404を表示
-  config.consider_all_requests_local = true
+  config.consider_all_requests_local = false
 
   # Enable/disable caching. By default caching is disabled.
   # Run rails dev:cache to toggle caching.

--- a/public/404.html
+++ b/public/404.html
@@ -6,7 +6,7 @@
   <style>
   .rails-default-error-page {
     background-color: #EFEFEF;
-    color: #2E2F30;
+    color: #7373FF;
     text-align: center;
     font-family: arial, sans-serif;
     margin: 0;
@@ -20,21 +20,30 @@
 
   .rails-default-error-page div.dialog > div {
     border: 1px solid #CCC;
-    border-right-color: #999;
-    border-left-color: #999;
-    border-bottom-color: #BBB;
-    border-top: #B00100 solid 4px;
-    border-top-left-radius: 9px;
-    border-top-right-radius: 9px;
     background-color: white;
     padding: 7px 12% 0;
     box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
   }
 
   .rails-default-error-page h1 {
-    font-size: 100%;
-    color: #730E15;
+    font-size: 50px;
+    color: #7373FF;
     line-height: 1.5em;
+  }
+
+  .rails-default-error-page button {
+    color: #7373FF;
+    line-height: 1.5em;
+    padding: 16px 32px;
+    margin: 32px;
+    background-color: #7373FF;
+    color: #FFF;
+    border: none;
+  }
+
+  .rails-default-error-page button:hover {
+    /* color: #7373FF; */
+    background-color: #72FFFF;
   }
 
   .rails-default-error-page div.dialog > p {
@@ -48,9 +57,36 @@
     border-bottom-left-radius: 4px;
     border-bottom-right-radius: 4px;
     border-top-color: #DADADA;
-    color: #666;
+    color: #7373FF;
     box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
   }
+
+  /* .flex {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    border: 3px solid #aaa;
+  } */
+
+  .flex > *{
+    text-align: center;
+     /* margin-left: 24px; */
+     padding: 4px 8px;
+     color: 7373FF;
+     text-decoration: none;
+     flex-grow: 1;
+  }
+  
+  a {
+    text-decoration: none;
+    color: #000;
+  }
+  
+  .flex > *:hover {
+      color: #FFF;
+      background-color: #72FFFF;
+  }
+  
   </style>
 </head>
 
@@ -58,10 +94,18 @@
   <!-- This file lives in public/404.html -->
   <div class="dialog">
     <div>
-      <h1>お探しのページは見つかりませんでした(404)</h1>
-      <p>ご指定のURLを再度ご確認ください</p>
+      <h1>404 Not Found</h1>
+      <p>お探しのページは見つかりませんでした。</p>
+      <p>URLが間違っているか、ページが存在しません。</p>
+      <p>下のリンク一覧から、他のページをご覧ください。</p>
+
+　　 　<div class="flex">
+        <p><a href="popular_contents">人気情報</a></p>
+        <p><a href="newest_contents">新着情報</a></p>
+        <p><a href="recommend_contents">オススメ情報</a></p>
+　　  </div>
+     <button onclick="location.href='/'">TOPページへ</button>
     </div>
-    <p><a href="/">トップページへ</a></p>
   </div>
 </body>
 </html>


### PR DESCRIPTION
## 実装の目的と概要
- TOP画像を小さくする
- 404にレイアウトを実装


## スクリーンショット（画面レイアウトを変更した場合）
<img width="1680" alt="スクリーンショット 2021-07-01 10 58 02" src="https://user-images.githubusercontent.com/64491435/124053521-61a4c700-da5b-11eb-86f5-49632154f260.png">

<img width="1680" alt="スクリーンショット 2021-07-01 10 58 18" src="https://user-images.githubusercontent.com/64491435/124053462-41750800-da5b-11eb-91f5-2b6d3af45c01.png">

## 参考資料
- [参考にしたいデザインが秀逸な404エラーページ11選！](https://www.leadplus.net/blog/404-error-pages.html)

## チェックリスト

- [x] ローカル環境での動作確認をしたか（影響し得る範囲も含めて）
- [x] rubocopを実行して警告が出力されていないか
- [x] GitHub で ファイル差分（Files changed）を確認し、内容が合っているか。不要なファイルに差分がでていないか
- [x] テストでエラーが発生していないか


