### PR TITLE
[改善]TagMasterのtag_typeにデフォルト値を実装

### DIFF
--- a/db/migrate/20210702043051_add_defaulttype_of_tag_master.rb
+++ b/db/migrate/20210702043051_add_defaulttype_of_tag_master.rb
@@ -1,0 +1,5 @@
+class AddDefaulttypeOfTagMaster < ActiveRecord::Migration[6.0]
+  def change
+    change_column :tag_masters, :tag_type, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_28_005111) do
+ActiveRecord::Schema.define(version: 2021_07_02_043051) do
 
   create_table "categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "name"
@@ -122,7 +122,7 @@ ActiveRecord::Schema.define(version: 2021_06_28_005111) do
 
   create_table "tag_masters", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "tag_name", null: false
-    t.integer "tag_type"
+    t.integer "tag_type", default: 0
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["tag_name"], name: "index_tag_masters_on_tag_name", unique: true


### PR DESCRIPTION
## 実装の目的と概要
- TagMasterのtag_typeにデフォルト値が実装されていなかったため、実装

## チェックリスト

- [x] ローカル環境での動作確認をしたか（影響し得る範囲も含めて）
- [x] rubocopを実行して警告が出力されていないか
- [x] GitHub で ファイル差分（Files changed）を確認し、内容が合っているか。不要なファイルに差分がでていないか
- [x] テストでエラーが発生していないか