### PR TITLE
[レイアウト]文字崩れを修正

### DIFF
--- a/app/views/homes/_main_content.html.erb
+++ b/app/views/homes/_main_content.html.erb
@@ -8,12 +8,14 @@
 <!--  人気情報 -->
 <div class="top-container">
   <div class="md:flex py-4">
-    <div class="borde top-content-title">
-      <h2>POPULAR</h2><span class="md:pt-2 block md:px-4 mt-2">人気情報</span>
+    <div class="borde top-content-title md:w-3/4">
+      <h2>POPULAR</h2>
+      <span class="md:pt-2 block md:px-4 mt-2">人気情報</span>
     </div>
-    <p class="top-link"><%= link_to ">>全て見る", popular_contents_path, class:"top-blue-btn" %></p>
+    <div class="top-link md:w-1/4">
+      <%= link_to ">>全て見る", popular_contents_path, class:"top-blue-btn" %>
+    </div>
   </div>
-  
   <div class="m-4">
     <div class="md:flex justify-center py-8 mb:py-16">
       <%= render partial: "layouts/top_page_content_card", collection: @popular_contents, as: "content" %>
@@ -21,16 +23,17 @@
   </div>
 </div>
 
-
-<!--  おすすめ情報 -->
+<!--  オススメ情報 -->
 <div class="top-container">
   <div class="md:flex py-4">
-    <div class="borde top-content-title">
-      <h2>RECOMMEND</h2><span class="md:pt-2 block md:px-4 mt-2">オススメ</span>
+    <div class="top-content-title md:w-3/4">
+      <h2>RECOMMEND</h2>
+      <span class="md:pt-2 block md:px-4 mt-2">オススメ</span>
     </div>
-    <p class="top-link"><%= link_to ">>全て見る", recommend_contents_path, class:"top-blue-btn" %></p>
+    <div class="top-link md:w-1/4">
+      <%= link_to ">>全て見る", recommend_contents_path, class:"top-blue-btn" %>
+    </div>
   </div>
-
   <div class="m-4">
     <div class="md:flex justify-center py-8 mb:py-16">
       <%= render partial: "layouts/top_page_content_card", collection: @recommend_contents, as: "content" %>
@@ -41,13 +44,15 @@
 
 <!--  新着情報 -->
 <div class="top-container">
-  <div class="md:flex py-4 ">
-    <div class="borde top-content-title">
-      <h2>NEWEST</h2><span class="md:pt-2 block md:px-4 mt-2">新着情報</span>
+  <div class="md:flex py-4">
+    <div class="borde top-content-title md:w-3/4">
+      <h2>NEWEST</h2>
+      <div class="md:pt-2 block md:p-4 mt-2">新着情報</div>
     </div>
-    <p class="top-link"><%= link_to ">>全て見る", newest_contents_path, class:"top-blue-btn" %></p>
+    <div class="top-link md:w-1/4">
+      <%= link_to ">>全て見る", newest_contents_path, class:"top-blue-btn" %>
+    </div>
   </div>
-
   <div class="m-4">
     <div class="md:flex justify-center py-8 mb:py-16">
       <%= render partial: "layouts/top_page_content_card", collection: @new_contents, as: "content" %>
@@ -58,15 +63,16 @@
 
 <!--  カテゴリー -->
 <div class="my-8 max-w-6xl mx-auto p-4">
-  
   <!-- タイトル-->
   <div class="md:flex py-4">
-    <div class="borde top-content-title">
-      <h2>CATEGORY</h2><span class="md:pt-2 block md:px-4 mt-2">カテゴリー</span>
+    <div class="borde top-content-title md:w-3/4">
+      <h2>CATEGORY</h2>
+      <div class="md:pt-2 block md:p-4 mt-2">カテゴリー</div>
     </div>
-    <p class="top-link"><%= link_to ">>全て見る", newest_contents_path, class:"top-blue-btn hidden" %></p>
+    <div class="top-link md:w-1/4">
+      <%= link_to ">>全て見る", newest_contents_path, class:"top-blue-btn hidden" %>
+    </div>
   </div>
-
   <!-- カテゴリーカード -->
   <div class="pb-8 mb:py-16">
     <%= render partial: "layouts/category_contents_card", collection: @categories, as: "category" %>


### PR DESCRIPTION
## 実装の目的と概要
- home/indexのタイトルで文字崩れが発生したため、修正した。

## スクリーンショット（画面レイアウトを変更した場合）
- before
<img width="696" alt="スクリーンショット 2021-07-02 13 39 01" src="https://user-images.githubusercontent.com/64491435/124225632-c424c280-db42-11eb-8da5-8dd51c1c0952.png">

- after
<img width="696" alt="スクリーンショット 2021-07-02 14 35 15" src="https://user-images.githubusercontent.com/64491435/124225639-c7b84980-db42-11eb-9b97-17f110ca9eab.png">


## チェックリスト

- [x] ローカル環境での動作確認をしたか（影響し得る範囲も含めて）
- [x] rubocopを実行して警告が出力されていないか
- [x] GitHub で ファイル差分（Files changed）を確認し、内容が合っているか。不要なファイルに差分がでていないか
- [x] テストでエラーが発生していないか
