### PR TITLE
[改善]サイドバーのレイアウトを修正

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -47,6 +47,6 @@ class ApplicationController < ActionController::Base
       # サイドバー
     def set_sidebar
       @content_tags = TagMaster.where(id: TagMaster.pluck(:id) & ContentTag.pluck(:tag_id)).order("RAND()")
-      @category_names = Category.order(created_at: :desc)
+      @category_names = Category.where(id: Content.distinct.select(:category_id)).order("RAND()")
     end
 end

--- a/app/controllers/homes_controller.rb
+++ b/app/controllers/homes_controller.rb
@@ -6,7 +6,5 @@ class HomesController < ApplicationController
     @recommend_contents = Content.published.recommend.order("RAND()").limit(TOP_PAGE_CONTENT)
     @new_contents = Content.published.order(created_at: :desc).first(TOP_PAGE_CONTENT)
     @categories = Category.order("RAND()").first(TOP_PAGE_CONTENT)
-    @category_names = Category.order(created_at: :desc)
-    @content_tags = TagMaster.where(id: TagMaster.pluck(:id) & ContentTag.pluck(:tag_id)).order("RAND()")
   end
 end

--- a/app/javascript/stylesheets/button.scss
+++ b/app/javascript/stylesheets/button.scss
@@ -50,7 +50,7 @@
 
 //カテゴリーキーワード(リンクあり)
 .category-tag-btn {
-  @apply text-white bg-dekiru-blue hover:bg-dekiru-light_blue border-0 m-1 py-2 px-6 focus:outline-none text-sm transition ease-in-out
+  @apply w-32 text-white bg-dekiru-blue hover:bg-dekiru-light_blue border-0 m-1 p-2 focus:outline-none text-sm transition ease-in-out
 }
 
 

--- a/app/views/homes/index.html.erb
+++ b/app/views/homes/index.html.erb
@@ -1,12 +1,12 @@
-<div class="md:flex">
+<div class="lg:flex">
 
   <!-- main_content -->
-  <div class="md:w-3/4">
+  <div class="lg:w-3/4">
     <%= render "main_content" , locals: @content_tags %>
   </div>
 
   <!-- side_content -->
-  <div class="md:w-1/4 md:ml-12">
+  <div class="md:ml-12 lg:w-1/4">
     <%= render "layouts/sidebar" %>
   </div>
 

--- a/app/views/layouts/_category_tags.html.erb
+++ b/app/views/layouts/_category_tags.html.erb
@@ -1,5 +1,5 @@
 <%= link_to category_path(category) do %>
-  <div class="flex my-4">
+  <div class="flex">
     <span class="category-tag-btn"><%= category.name %></span>
   </div>
 <% end %>

--- a/app/views/layouts/_content_tag.html.erb
+++ b/app/views/layouts/_content_tag.html.erb
@@ -1,5 +1,5 @@
 <%= link_to search_contents_path(tag_id: tag.id) do %>
-  <div class="flex my-4">
-    <span class="content-tag-btn text-sm"><%= tag[:tag_name] %></span>
+  <div class="flex">
+    <span class="content-tag-btn text-sm w-32"><%= tag[:tag_name] %></span>
   </div>
 <% end %>

--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -10,7 +10,7 @@
       <!--後で調整  <p class="top-link"><%= link_to ">>全て見る", categories_path, class:"blue-link" %></p>-->
     </div>
     <!-- キーワードリンク-->
-    <div class="flex justify-start flex-wrap my-1 max-w-6xl px-4">
+    <div class="flex justify-stared md:justify-center flex-wrap my-1 max-w-6xl px-4">
       <%= render partial: "layouts/content_tag", collection: @content_tags, as: "tag" %>
     </div>
   </div>
@@ -24,7 +24,7 @@
       <!--後で調整  <p class="top-link"><%= link_to ">>全て見る", categories_path, class:"blue-link" %></p>-->
     </div>
     <!-- カテゴリーリンク-->
-    <div class="flex justify-start flex-wrap my-1 max-w-6xl px-4"> 
+    <div class="flex justify-stared md:justify-center flex-wrap my-1 max-w-6xl px-4"> 
       <%= render partial: "layouts/category_tags", collection: @category_names, as: "category" %>
     </div>
   </div>


### PR DESCRIPTION
## 実装の目的と概要
- タグの幅を統一
- カテゴリーがコンテンツに登録されていない場合、リンクタグを非表示

## スクリーンショット（画面レイアウトを変更した場合）
<img width="1680" alt="スクリーンショット 2021-07-04 15 34 54" src="https://user-images.githubusercontent.com/64491435/124375489-69739e00-dcdd-11eb-865d-6e9f709b6722.png">


## 参考資料
- [【Rails】 distinctメソッドでユニークなデータを取得する方法](https://pikawaka.com/rails/distinct)
## チェックリスト

- [x] ローカル環境での動作確認をしたか（影響し得る範囲も含めて）
- [x] rubocopを実行して警告が出力されていないか
- [x] GitHub で ファイル差分（Files changed）を確認し、内容が合っているか。不要なファイルに差分がでていないか
- [x] テストでエラーが発生していないか