### PR TITLE
[改善]headerに条件分岐を追加

### DIFF
--- a/app/views/layouts/_md_header.html.erb
+++ b/app/views/layouts/_md_header.html.erb
@@ -63,6 +63,7 @@
       </div>
 
       <!-- お気に入り -->
+      <% if user_signed_in? %>
       <div>
         <%= link_to favorite_contents_path do %>
           <div class="px-8 hover:text-dekiru-blue">
@@ -71,6 +72,7 @@
           </div>
         <% end %>
       </div>
+      <% end %>
 
     </div>
   </div>


### PR DESCRIPTION
## 実装の目的と概要
- headerに条件分岐が実装されていなかったため、実装。

## スクリーンショット（画面レイアウトを変更した場合）
<img width="1680" alt="スクリーンショット 2021-07-04 21 45 23" src="https://user-images.githubusercontent.com/64491435/124385611-714d3580-dd11-11eb-8be7-d42700784486.png">


<img width="1680" alt="スクリーンショット 2021-07-04 21 45 32" src="https://user-images.githubusercontent.com/64491435/124385618-78744380-dd11-11eb-844b-df6bb718e0e1.png">

## チェックリスト

- [x] ローカル環境での動作確認をしたか（影響し得る範囲も含めて）
- [x] rubocopを実行して警告が出力されていないか
- [x] GitHub で ファイル差分（Files changed）を確認し、内容が合っているか。不要なファイルに差分がでていないか
- [x] テストでエラーが発生していないか
